### PR TITLE
ability to send input from netbeans to application

### DIFF
--- a/src/org/netbeans/gradle/project/tasks/GradleTasks.java
+++ b/src/org/netbeans/gradle/project/tasks/GradleTasks.java
@@ -45,6 +45,7 @@ import org.openide.LifecycleManager;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.util.RequestProcessor;
+import org.openide.util.io.ReaderInputStream;
 import org.openide.windows.OutputWriter;
 
 public final class GradleTasks {
@@ -196,7 +197,12 @@ public final class GradleTasks {
 
         buildLauncher.setStandardOutput(new WriterOutputStream(forwardedStdOut));
         buildLauncher.setStandardError(new WriterOutputStream(forwardedStdErr));
-        buildLauncher.setStandardInput(new ReaderInputStream(buildIn));
+        
+        try {
+            buildLauncher.setStandardInput(new ReaderInputStream(buildIn));
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, "Could not create input stream", e);
+        }
 
         return new OutputRef(forwardedStdOut, forwardedStdErr);
     }
@@ -365,140 +371,6 @@ public final class GradleTasks {
         @Override
         public void run() {
             submitGradleTask(project, taskDefFactroy);
-        }
-    }
-
-    private static class ReaderInputStream extends InputStream {
-        private final Reader reader;
-        private final Charset encoding;
-        private final AtomicReference<byte[]> cacheRef;
-
-        public ReaderInputStream(Reader reader) {
-            this(reader, Charset.defaultCharset());
-        }
-
-        public ReaderInputStream(Reader reader, Charset encoding) {
-            if (reader == null) throw new NullPointerException("reader");
-            if (encoding == null) throw new NullPointerException("encoding");
-
-            this.reader = reader;
-            this.encoding = encoding;
-            this.cacheRef = new AtomicReference<byte[]>(new byte[0]);
-        }
-
-        private int readFromCache(byte[] b, int offset, int length) {
-            byte[] cache;
-            byte[] newCache;
-            int toRead;
-            do {
-                cache = cacheRef.get();
-                toRead = Math.min(cache.length, length);
-                System.arraycopy(cache, 0, b, offset, toRead);
-                newCache = new byte[cache.length - toRead];
-                System.arraycopy(cache, toRead, newCache, 0, newCache.length);
-            } while (!cacheRef.compareAndSet(cache, newCache));
-
-            return toRead;
-        }
-
-        private boolean readToCache(int requiredBytes) throws IOException {
-            assert requiredBytes > 0;
-            // We rely on the encoder to choose the number of bytes to read but
-            // it does not have to be actually accurate, it only matters
-            // performance wise but this is not a performance critical code.
-
-            CharsetEncoder encoder = encoding.newEncoder();
-            int toRead = (int)((float)requiredBytes / encoder.averageBytesPerChar()) + 1;
-            toRead = Math.max(toRead, requiredBytes);
-
-            char[] readChars = new char[toRead];
-            int readCount = reader.read(readChars);
-            if (readCount <= 0) {
-                // readCount should never be zero but if reader returns zero
-                // regardless, assume that it believes that EOF has been
-                // reached.
-                return false;
-            }
-
-            ByteBuffer encodedBuffer = encoder.encode(CharBuffer.wrap(readChars, 0, readCount));
-            byte[] encoded = new byte[encodedBuffer.remaining()];
-            encodedBuffer.get(encoded);
-
-            byte[] oldCache;
-            byte[] newCache;
-
-            do {
-                oldCache = cacheRef.get();
-                newCache = new byte[oldCache.length + encoded.length];
-                System.arraycopy(oldCache, 0, newCache, 0, oldCache.length);
-                System.arraycopy(encoded, 0, newCache, oldCache.length, encoded.length);
-            } while (!cacheRef.compareAndSet(oldCache, newCache));
-            return true;
-        }
-
-        @Override
-        public int read() throws IOException {
-            byte[] result = new byte[1];
-            if (read(result) <= 0) {
-                // Althouth the above read should never return zero.
-                return -1;
-            }
-            else {
-                return ((int)result[0] & 0xFF);
-            }
-        }
-
-        @Override
-        public int read(byte[] b) throws IOException {
-            return read(b, 0, b.length);
-        }
-
-        @Override
-        public int read(byte[] b, int off, int len) throws IOException {
-            // Note that while this method is implemented to be thread-safe
-            // calling it concurrently is unadvised, since read is not atomic.
-            if (b == null) {
-                throw new NullPointerException();
-            } else if (off < 0 || len < 0 || len > b.length - off) {
-                throw new IndexOutOfBoundsException();
-            } else if (len == 0) {
-                return 0;
-            }
-
-            int currentOffset = off;
-            int currentLength = len;
-            int readCount = 0;
-            do {
-                int currentRead = readFromCache(b, currentOffset, currentLength);
-                readCount += currentRead;
-                currentOffset += currentRead;
-                currentLength -= currentRead;
-
-                if (readCount > 0) {
-                    return readCount;
-                }
-            } while (readToCache(currentLength));
-
-            return readCount > 0 ? readCount : -1;
-        }
-
-        @Override
-        public void close() throws IOException {
-            reader.close();
-        }
-
-        @Override
-        public void mark(int readlimit) {
-        }
-
-        @Override
-        public void reset() throws IOException {
-            throw new IOException("mark/reset not supported");
-        }
-
-        @Override
-        public boolean markSupported() {
-            return false;
         }
     }
 


### PR DESCRIPTION
Attila, could you merge this simple change?

I did see your comment on ReaderInputStream saying that gradle doesn't provide a way to send input to applications. But actually there is a way:  http://gradle.org/docs/current/dsl/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:standardInput

If you merge the change, I'll use the input as workaround to my favorite issue #21. My application (jetty webserver) will be reading the input (in the development environment only) and stop itself if the input is closed.
