### PR TITLE
Improve output window captions

### DIFF
--- a/src/org/netbeans/gradle/project/properties/PredefinedTask.java
+++ b/src/org/netbeans/gradle/project/properties/PredefinedTask.java
@@ -82,6 +82,14 @@ public final class PredefinedTask {
         return jvmArguments;
     }
 
+    public List<String> getProcessedTaskNames(Map<String, String> varReplaceMap) {
+        List<String> processedTaskNames = new LinkedList<String>();
+        for (Name name: taskNames) {
+            processedTaskNames.add(processString(name.getName(), varReplaceMap));
+        }
+        return processedTaskNames;
+    }
+
     private static boolean isLocalTaskExists(NbGradleModule module, String task) {
         for (NbGradleTask moduleTask: module.getTasks()) {
             if (moduleTask.getLocalName().equals(task)) {
@@ -164,7 +172,7 @@ public final class PredefinedTask {
         return builder;
     }
     
-    private static String getCaption(String projectName, List<String> taskNames, boolean nonBlocking) {
+    public static String getCaption(String projectName, List<String> taskNames, boolean nonBlocking) {
         boolean fullyQualified = true;
         for (String taskName: taskNames) {
             fullyQualified &= taskName.startsWith(":");
@@ -220,10 +228,7 @@ public final class PredefinedTask {
     }
 
     public GradleTaskDef.Builder createTaskDefBuilder(String caption, Map<String, String> varReplaceMap) {
-        List<String> processedTaskNames = new LinkedList<String>();
-        for (Name name: taskNames) {
-            processedTaskNames.add(processString(name.getName(), varReplaceMap));
-        }
+        List<String> processedTaskNames = getProcessedTaskNames(varReplaceMap);
 
         GradleTaskDef.Builder builder = new GradleTaskDef.Builder(caption, processedTaskNames);
         builder.setArguments(processList(arguments, varReplaceMap));

--- a/src/org/netbeans/gradle/project/view/GradleActionProvider.java
+++ b/src/org/netbeans/gradle/project/view/GradleActionProvider.java
@@ -186,11 +186,9 @@ public final class GradleActionProvider implements ActionProvider {
 
         String caption;
         switch (kind) {
-            case DEBUG:
-                caption = project.getDisplayName() + " - debug";
-                break;
             case RUN:
-                caption = project.getDisplayName() + " - run";
+            case DEBUG:
+                caption = PredefinedTask.getCaption(project.getDisplayName(), task.getProcessedTaskNames(varReplaceMap), false);
                 break;
             case BUILD:
                 caption = project.getDisplayName();


### PR DESCRIPTION
My apologies, I have one more improvement for consideration :)

The goal of the improvement is to provide descriptive (and possibly short) captions of the output windows.

The first of the commits (1b0efde4273ef00f561207bb0862cf74eed0cabb) concerns the custom tasks only.
Suppose, all gradle task names of a custom task are fully qualified (start with colon). In this case the name of the project, on which the custom task is being executed, is redundant. More importantly, the project name in the caption would be confusing, so it is better to omit it.
That is what the commit does: if all task names start with colon, it removes the project name from the caption. Overwise, the behavior is almost the same as before. I say "almost" because there will be no brackets surrounding the task names, is that a problem?

The second commit (39deae6bb8085c1ca1d96a8b8fb459d2b4a94ff0) is slightly more risky. It expands the same approach to the built-in tasks.
If the default "run" or "debug" tasks have not been overridden, the behavior will be the same as before the change: the caption will take form of "<Project name> - run" or "<Project name> - debug".
However, if the built-in tasks are overridden, the corresponding gradle task names will be listed. And again, if all of the gradle tasks start with colon, the project name will be omitted.

Please let me know if there is anything wrong with the changes, I'll gladly correct them.
Thanks.
