### PR TITLE
Builder pattern in commands API.

### DIFF
--- a/src/org/netbeans/gradle/project/api/task/CustomCommandActions.java
+++ b/src/org/netbeans/gradle/project/api/task/CustomCommandActions.java
@@ -84,36 +84,6 @@ public final class CustomCommandActions {
         }
 
         /**
-         * Returns the kind of tasks affecting the output window handling of the
-         * executed task.
-         *
-         * @return the kind of tasks affecting the output window handling of the
-         *   executed task. This method may never return {@code null}.
-         */
-        public TaskKind getTaskKind() {
-            return taskKind;
-        }
-
-        /**
-         * Returns the {@code CommandCompleteListener} last set by the
-         * {@link #setCommandCompleteListener(CommandCompleteListener) setCommandCompleteListener}
-         * method.
-         * <P>
-         * The default value for this property is {@code null}.
-         * <P>
-         * The {@code CommandCompleteListener} is executed after the associated
-         * Gradle commands completes.
-         *
-         * @return the {@code CommandCompleteListener} last set by the
-         *   {@link #setCommandCompleteListener(CommandCompleteListener) setCommandCompleteListener}
-         *   method. This method may return {@code null} if {@code null} was
-         *   set.
-         */
-        public CommandCompleteListener getCommandCompleteListener() {
-            return commandCompleteListener;
-        }
-
-        /**
          * Sets the {@code CommandCompleteListener} to be executed after the
          * associated Gradle command completes. An invocation of this method
          * overwrites previous invocation of this method.
@@ -126,27 +96,9 @@ public final class CustomCommandActions {
          *   argument can be {@code null}, if there is nothing to do after the
          *   Gradle command completes.
          */
-        public void setCommandCompleteListener(CommandCompleteListener commandCompleteListener) {
+        public Builder setCommandCompleteListener(CommandCompleteListener commandCompleteListener) {
             this.commandCompleteListener = commandCompleteListener;
-        }
-
-        /**
-         * Returns the {@code TaskOutputProcessor} last set by the
-         * {@link #setStdOutProcessor(TaskOutputProcessor) setStdOutProcessor}
-         * method.
-         * <P>
-         * The default value for this property is {@code null}.
-         * <P>
-         * The {@code TaskOutputProcessor} is called after each line written to
-         * the standard output by the associated Gradle command.
-         *
-         * @return the {@code TaskOutputProcessor} last set by the
-         *   {@link #setStdOutProcessor(TaskOutputProcessor) setStdOutProcessor}
-         *   method. This method may return {@code null} if {@code null} was
-         *   set.
-         */
-        public TaskOutputProcessor getStdOutProcessor() {
-            return stdOutProcessor;
+            return this;
         }
 
         /**
@@ -163,27 +115,9 @@ public final class CustomCommandActions {
          *   Gradle command. This argument can be {@code null}, if there is
          *   nothing to do after lines are written to the standard output.
          */
-        public void setStdOutProcessor(TaskOutputProcessor stdOutProcessor) {
+        public Builder setStdOutProcessor(TaskOutputProcessor stdOutProcessor) {
             this.stdOutProcessor = stdOutProcessor;
-        }
-
-        /**
-         * Returns the {@code TaskOutputProcessor} last set by the
-         * {@link #setStdErrProcessor(TaskOutputProcessor) setStdErrProcessor}
-         * method.
-         * <P>
-         * The default value for this property is {@code null}.
-         * <P>
-         * The {@code TaskOutputProcessor} is called after each line written to
-         * the standard error by the associated Gradle command.
-         *
-         * @return the {@code TaskOutputProcessor} last set by the
-         *   {@link #setStdErrProcessor(TaskOutputProcessor) setStdErrProcessor}
-         *   method. This method may return {@code null} if {@code null} was
-         *   set.
-         */
-        public TaskOutputProcessor getStdErrProcessor() {
-            return stdErrProcessor;
+            return this;
         }
 
         /**
@@ -200,8 +134,9 @@ public final class CustomCommandActions {
          *   Gradle command. This argument can be {@code null}, if there is
          *   nothing to do after lines are written to the standard error.
          */
-        public void setStdErrProcessor(TaskOutputProcessor stdErrProcessor) {
+        public Builder setStdErrProcessor(TaskOutputProcessor stdErrProcessor) {
             this.stdErrProcessor = stdErrProcessor;
+            return this;
         }
 
         /**
@@ -224,10 +159,10 @@ public final class CustomCommandActions {
     private final TaskOutputProcessor stdErrProcessor;
 
     private CustomCommandActions(Builder builder) {
-        this.taskKind = builder.getTaskKind();
-        this.commandCompleteListener = builder.getCommandCompleteListener();
-        this.stdOutProcessor = builder.getStdOutProcessor();
-        this.stdErrProcessor = builder.getStdErrProcessor();
+        this.taskKind = builder.taskKind;
+        this.commandCompleteListener = builder.commandCompleteListener;
+        this.stdOutProcessor = builder.stdOutProcessor;
+        this.stdErrProcessor = builder.stdErrProcessor;
     }
 
     /**

--- a/src/org/netbeans/gradle/project/api/task/GradleCommandTemplate.java
+++ b/src/org/netbeans/gradle/project/api/task/GradleCommandTemplate.java
@@ -1,5 +1,6 @@
 package org.netbeans.gradle.project.api.task;
 
+import com.google.common.base.Preconditions;
 import java.util.Collections;
 import java.util.List;
 import org.netbeans.gradle.project.CollectionUtils;
@@ -78,40 +79,6 @@ public final class GradleCommandTemplate {
         }
 
         /**
-         * Returns the list of tasks to be executed by Gradle. Tasks will be
-         * executed in the order they were specified if possible without
-         * violating task dependencies. This property can only be specified at
-         * construction time. The task names may contain
-         * {@link TaskVariable variables to be replaced}.
-         *
-         * @return the list of tasks to be executed by Gradle. This method never
-         *   returns {@code null}, the returned list does not contain
-         *   {@code null} elements and is never empty.
-         */
-        public List<String> getTasks() {
-            return tasks;
-        }
-
-        /**
-         * Returns the last set arguments for this Gradle command.
-         * <P>
-         * The default value for this property if unset is an empty list.
-         * <P>
-         * Note: These arguments are specified for Gradle itself and not for the
-         * JVM executing Gradle. JVM arguments need to be specified via the
-         * {@link #setJvmArguments(List) JvmArguments} property.
-         *
-         * @return the last set arguments for this Gradle command. This method
-         *   never returns {@code null} and the returned list does not contain
-         *   {@code null} elements but may be empty.
-         *
-         * @see #setArguments(List)
-         */
-        public List<String> getArguments() {
-            return arguments;
-        }
-
-        /**
          * Sets the arguments specified for the Gradle command. This method call
          * overwrites the values set by previous {@code setArguments} calls. The
          * arguments may contain {@link TaskVariable variables to be replaced}.
@@ -129,33 +96,14 @@ public final class GradleCommandTemplate {
          * @throws NullPointerException thrown if the specified list is
          *   {@code null} or contains {@code null} elements
          */
-        public void setArguments(List<String> arguments) {
+        public Builder setArguments(List<String> arguments) {
             this.arguments = CollectionUtils.copyNullSafeList(arguments);
+            return this;
         }
 
-        /**
-         * Returns the last set JVM arguments for this Gradle command.
-         * These arguments are used to start the JVM process executing Gradle
-         * which is executing the Gradle command.
-         * <P>
-         * Note: Users may specify additional JVM arguments in the global
-         * settings and these JVM arguments will be added regardless what is
-         * specified in this list.
-         * <P>
-         * <B>Warning</B>: Specifying different JVM arguments for different
-         * commands are likely to spawn a new Gradle daemon. Note that the
-         * Gradle daemon is a long lived process and by default has a
-         * considerable memory footprint. Therefore, spawning new Gradle daemons
-         * should be avoided if possible.
-         *
-         * @return the last set JVM arguments for this Gradle command. This
-         *   method never returns {@code null} and the returned list does not
-         *   contain {@code null} elements but may be empty.
-         *
-         * @see #setJvmArguments(List)
-         */
-        public List<String> getJvmArguments() {
-            return jvmArguments;
+        public Builder addArgument(String argument) {
+            arguments.add(Preconditions.checkNotNull(argument));
+            return this;
         }
 
         /**
@@ -180,31 +128,9 @@ public final class GradleCommandTemplate {
          * @throws NullPointerException thrown if the specified list is
          *   {@code null} or contains {@code null} elements
          */
-        public void setJvmArguments(List<String> jvmArguments) {
+        public Builder setJvmArguments(List<String> jvmArguments) {
             this.jvmArguments = CollectionUtils.copyNullSafeList(jvmArguments);
-        }
-
-        /**
-         * Returns {@code true} if this Gradle command might block other
-         * commands indefinitely.
-         * <P>
-         * Gradle commands will be executed so that if a task is not blocking
-         * (this method returns {@code false}), then all subsequent tasks will
-         * wait for the non-blocking task to complete. The reason for this
-         * distinction is to prevent accidentally starting multiple Gradle
-         * daemons if multiple Gradle commands are scheduled concurrently.
-         * <P>
-         * <P>
-         * An example for a blocking task is "debug". An example for a
-         * non-blocking task is "build".
-         *
-         * @return {@code true} if this Gradle command might block other
-         *   commands indefinitely, {@code false} otherwise
-         *
-         * @see #setBlocking(boolean)
-         */
-        public boolean isBlocking() {
-            return blocking;
+            return this;
         }
 
         /**
@@ -224,8 +150,9 @@ public final class GradleCommandTemplate {
          * @param blocking {@code true} if this Gradle command might block other
          *   commands indefinitely, {@code false} otherwise
          */
-        public void setBlocking(boolean blocking) {
+        public Builder setBlocking(boolean blocking) {
             this.blocking = blocking;
+            return this;
         }
 
         /**
@@ -248,10 +175,11 @@ public final class GradleCommandTemplate {
     private final boolean blocking;
 
     private GradleCommandTemplate(Builder builder) {
-        this.tasks = builder.getTasks();
-        this.arguments = builder.getArguments();
-        this.jvmArguments = builder.getJvmArguments();
-        this.blocking = builder.isBlocking();
+        // XXX better to make a copy if we want to ensure immutability
+        this.tasks = builder.tasks;
+        this.arguments = builder.arguments;
+        this.jvmArguments = builder.jvmArguments;
+        this.blocking = builder.blocking;
     }
 
     /**

--- a/src/org/netbeans/gradle/project/java/tasks/GradleJavaBuiltInCommands.java
+++ b/src/org/netbeans/gradle/project/java/tasks/GradleJavaBuiltInCommands.java
@@ -1,6 +1,5 @@
 package org.netbeans.gradle.project.java.tasks;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -141,9 +140,9 @@ public final class GradleJavaBuiltInCommands implements BuiltInGradleCommandQuer
     }
 
     private CustomCommandActions debugActions(boolean test) {
-        CustomCommandActions.Builder result = new CustomCommandActions.Builder(TaskKind.DEBUG);
-        result.setStdOutProcessor(new DebugTextListener(new AttacherListener(javaExt, test)));
-        return result.create();
+        return new CustomCommandActions.Builder(TaskKind.DEBUG).
+                setStdOutProcessor(new DebugTextListener(new AttacherListener(javaExt, test))).
+                create();
     }
 
     private static CommandWithActions blockingCommand(
@@ -162,10 +161,10 @@ public final class GradleJavaBuiltInCommands implements BuiltInGradleCommandQuer
             CustomCommandActions customActions,
             boolean skipTestsIfNeeded) {
 
-        GradleCommandTemplate.Builder commandBuilder = new GradleCommandTemplate.Builder(taskNames);
-        commandBuilder.setArguments(arguments);
-        commandBuilder.setJvmArguments(jvmArguments);
-        commandBuilder.setBlocking(true);
+        GradleCommandTemplate.Builder commandBuilder = new GradleCommandTemplate.Builder(taskNames).
+                setArguments(arguments).
+                setJvmArguments(jvmArguments).
+                setBlocking(true);
 
         return new CommandWithActions(commandBuilder.create(), customActions, skipTestsIfNeeded);
     }
@@ -185,10 +184,10 @@ public final class GradleJavaBuiltInCommands implements BuiltInGradleCommandQuer
             CustomCommandActions customActions,
             boolean skipTestsIfNeeded) {
 
-        GradleCommandTemplate.Builder commandBuilder = new GradleCommandTemplate.Builder(taskNames);
-        commandBuilder.setArguments(arguments);
-        commandBuilder.setJvmArguments(jvmArguments);
-        commandBuilder.setBlocking(false);
+        GradleCommandTemplate.Builder commandBuilder = new GradleCommandTemplate.Builder(taskNames).
+                setArguments(arguments).
+                setJvmArguments(jvmArguments).
+                setBlocking(false);
 
         return new CommandWithActions(commandBuilder.create(), customActions, skipTestsIfNeeded);
     }
@@ -209,13 +208,10 @@ public final class GradleJavaBuiltInCommands implements BuiltInGradleCommandQuer
 
         public GradleCommandTemplate getCommand() {
             if (skipTestsIfNeeded && GlobalConfig.skipTests().getValue()) {
-                GradleCommandTemplate.Builder builder = new GradleCommandTemplate.Builder(command);
-                List<String> prevArguments = builder.getArguments();
-                List<String> newArguments = new ArrayList<String>(prevArguments.size() + 2);
-                newArguments.add("-x");
-                newArguments.add("test");
-                builder.setArguments(newArguments);
-                return builder.create();
+                return new GradleCommandTemplate.Builder(command).
+                        addArgument("-x").
+                        addArgument("test").
+                        create();
             }
             return command;
         }

--- a/src/org/netbeans/gradle/project/properties/PredefinedTask.java
+++ b/src/org/netbeans/gradle/project/properties/PredefinedTask.java
@@ -156,11 +156,11 @@ public final class PredefinedTask {
             rawTaskNames.add(name.getName());
         }
 
-        GradleCommandTemplate.Builder builder = new GradleCommandTemplate.Builder(rawTaskNames);
-        builder.setArguments(arguments);
-        builder.setJvmArguments(jvmArguments);
-        builder.setBlocking(!nonBlocking);
-        return builder.create();
+        return new GradleCommandTemplate.Builder(rawTaskNames).
+                setArguments(arguments).
+                setJvmArguments(jvmArguments).
+                setBlocking(!nonBlocking).
+                create();
     }
 
     public boolean isTasksExistsIfRequired(NbGradleProject project, Lookup actionContext) {

--- a/src/org/netbeans/gradle/project/tasks/DefaultBuiltInTasks.java
+++ b/src/org/netbeans/gradle/project/tasks/DefaultBuiltInTasks.java
@@ -140,12 +140,12 @@ public final class DefaultBuiltInTasks implements BuiltInGradleCommandQuery {
             List<String> jvmArguments,
             CustomCommandActions customActions) {
 
-        GradleCommandTemplate.Builder commandBuilder = new GradleCommandTemplate.Builder(taskNames);
-        commandBuilder.setArguments(arguments);
-        commandBuilder.setJvmArguments(jvmArguments);
-        commandBuilder.setBlocking(true);
+        GradleCommandTemplate command = new GradleCommandTemplate.Builder(taskNames).
+                setArguments(arguments).
+                setJvmArguments(jvmArguments).
+                setBlocking(true).create();
 
-        return new CommandWithActions(commandBuilder.create(), customActions);
+        return new CommandWithActions(command, customActions);
     }
 
     private static CommandWithActions nonBlockingCommand(
@@ -154,12 +154,12 @@ public final class DefaultBuiltInTasks implements BuiltInGradleCommandQuery {
             List<String> jvmArguments,
             CustomCommandActions customActions) {
 
-        GradleCommandTemplate.Builder commandBuilder = new GradleCommandTemplate.Builder(taskNames);
-        commandBuilder.setArguments(arguments);
-        commandBuilder.setJvmArguments(jvmArguments);
-        commandBuilder.setBlocking(false);
+        GradleCommandTemplate command = new GradleCommandTemplate.Builder(taskNames).
+                setArguments(arguments).
+                setJvmArguments(jvmArguments).
+                setBlocking(false).create();
 
-        return new CommandWithActions(commandBuilder.create(), customActions);
+        return new CommandWithActions(command, customActions);
     }
 
     private static final class CommandWithActions {

--- a/src/org/netbeans/gradle/project/view/CustomActionPanel.java
+++ b/src/org/netbeans/gradle/project/view/CustomActionPanel.java
@@ -44,11 +44,10 @@ public class CustomActionPanel extends javax.swing.JPanel {
             return null;
         }
 
-        GradleCommandTemplate.Builder builder = new GradleCommandTemplate.Builder(Arrays.asList(tasks));
-        builder.setArguments(Arrays.asList(getArguments()));
-        builder.setJvmArguments(Arrays.asList(getJvmArguments()));
-        builder.setBlocking(!isNonBlocking());
-        return builder.create();
+        return new GradleCommandTemplate.Builder(Arrays.asList(tasks)).
+                setArguments(Arrays.asList(getArguments())).
+                setJvmArguments(Arrays.asList(getJvmArguments())).
+                setBlocking(!isNonBlocking()).create();
     }
 
     public String[] getTasks() {

--- a/src/org/netbeans/gradle/project/view/GradleProjectLogicalViewProvider.java
+++ b/src/org/netbeans/gradle/project/view/GradleProjectLogicalViewProvider.java
@@ -657,10 +657,10 @@ public final class GradleProjectLogicalViewProvider implements LogicalViewProvid
                 menuItem.addActionListener(new ActionListener() {
                     @Override
                     public void actionPerformed(ActionEvent e) {
-                        GradleCommandTemplate.Builder command
-                                = new GradleCommandTemplate.Builder(Arrays.asList(task.getPath()));
+                        GradleCommandTemplate command = 
+                                new GradleCommandTemplate.Builder(Arrays.asList(task.getPath())).create();
 
-                        executeCommandTemplate(project, command.create());
+                        executeCommandTemplate(project, command);
                     }
                 });
                 menu.add(menuItem);


### PR DESCRIPTION
Avoid getters in builder object and 
simply chain the construction of result.

I think we should follow builder pattern more precisely since it is going to be part of API.

as for the chaining I do not have too strong opinion.
