### PR TITLE
issue 68 - clean up UI of new project wizards

### DIFF
--- a/src/main/java/org/netbeans/gradle/project/newproject/GradleMultiProjectConfigPanel.java
+++ b/src/main/java/org/netbeans/gradle/project/newproject/GradleMultiProjectConfigPanel.java
@@ -9,18 +9,20 @@ import org.openide.util.HelpCtx;
 public final class GradleMultiProjectConfigPanel implements WizardDescriptor.Panel<WizardDescriptor> {
     private final AtomicReference<GradleMultiProjectPropertiesPanel> panel;
     private final AtomicReference<GradleMultiProjectConfig> configRef;
+    private final WizardDescriptor wizard;
 
-    public GradleMultiProjectConfigPanel(AtomicReference<GradleMultiProjectConfig> configRef) {
+    public GradleMultiProjectConfigPanel(AtomicReference<GradleMultiProjectConfig> configRef, WizardDescriptor wizard) {
         if (configRef == null) throw new NullPointerException("configRef");
 
         this.configRef = configRef;
         this.panel = new AtomicReference<GradleMultiProjectPropertiesPanel>();
+        this.wizard = wizard;
     }
 
     private GradleMultiProjectPropertiesPanel getPanel() {
         GradleMultiProjectPropertiesPanel result = panel.get();
         if (result == null) {
-            panel.compareAndSet(null, new GradleMultiProjectPropertiesPanel());
+            panel.compareAndSet(null, new GradleMultiProjectPropertiesPanel(wizard));
             result = panel.get();
         }
         return result;

--- a/src/main/java/org/netbeans/gradle/project/newproject/GradleMultiProjectPropertiesPanel.form
+++ b/src/main/java/org/netbeans/gradle/project/newproject/GradleMultiProjectPropertiesPanel.form
@@ -19,31 +19,23 @@
           <Group type="102" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="jProjectLocationCaption" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="jProjectNameCaption" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="jProjectFolderLocationLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="jMavenGroupCaption" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="jMavenVersionCaption" alignment="0" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="jProjectNameEdit" max="32767" attributes="0"/>
+                  <Component id="jProjectFolderEdit" alignment="1" max="32767" attributes="0"/>
                   <Group type="102" alignment="0" attributes="0">
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="jProjectLocationCaption" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="jProjectNameCaption" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="jProjectFolderLocationLabel" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="jMavenGroupCaption" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="jMavenVersionCaption" alignment="0" min="-2" max="-2" attributes="0"/>
-                      </Group>
+                      <Component id="jProjectLocationEdit" pref="337" max="32767" attributes="0"/>
                       <EmptySpace max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="jProjectNameEdit" max="32767" attributes="0"/>
-                          <Component id="jProjectFolderEdit" alignment="1" max="32767" attributes="0"/>
-                          <Group type="102" alignment="0" attributes="0">
-                              <Component id="jProjectLocationEdit" pref="337" max="32767" attributes="0"/>
-                              <EmptySpace max="-2" attributes="0"/>
-                              <Component id="jBrowseButton" min="-2" max="-2" attributes="0"/>
-                          </Group>
-                          <Component id="jMavenGroupEdit" alignment="0" max="32767" attributes="0"/>
-                          <Component id="jMavenVersionEdit" alignment="0" max="32767" attributes="0"/>
-                      </Group>
+                      <Component id="jBrowseButton" min="-2" max="-2" attributes="0"/>
                   </Group>
-                  <Group type="102" alignment="0" attributes="0">
-                      <Component id="jInformationLabel" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
-                  </Group>
+                  <Component id="jMavenGroupEdit" alignment="0" max="32767" attributes="0"/>
+                  <Component id="jMavenVersionEdit" alignment="0" max="32767" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
@@ -78,9 +70,7 @@
                   <Component id="jMavenVersionEdit" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="jMavenVersionCaption" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace pref="30" max="32767" attributes="0"/>
-              <Component id="jInformationLabel" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
+              <EmptySpace pref="52" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -154,11 +144,6 @@
     <Component class="javax.swing.JLabel" name="jMavenVersionCaption">
       <Properties>
         <Property name="text" type="java.lang.String" value="Maven Version:"/>
-      </Properties>
-    </Component>
-    <Component class="javax.swing.JLabel" name="jInformationLabel">
-      <Properties>
-        <Property name="text" type="java.lang.String" value="NO_MESSAGE"/>
       </Properties>
     </Component>
   </SubComponents>

--- a/src/main/java/org/netbeans/gradle/project/newproject/GradleMultiProjectPropertiesPanel.java
+++ b/src/main/java/org/netbeans/gradle/project/newproject/GradleMultiProjectPropertiesPanel.java
@@ -7,16 +7,19 @@ import javax.swing.event.DocumentListener;
 import org.netbeans.gradle.project.validate.BackgroundValidator;
 import org.netbeans.gradle.project.validate.GroupValidator;
 import org.netbeans.gradle.project.validate.Validators;
+import org.openide.WizardDescriptor;
 
 @SuppressWarnings("serial")
 public class GradleMultiProjectPropertiesPanel extends javax.swing.JPanel {
     private final GroupValidator validators;
     private final BackgroundValidator bckgValidator;
+    private final WizardDescriptor wizard;
 
     /**
      * Creates new form GradleMultiProjectPropertiesPanel
      */
-    public GradleMultiProjectPropertiesPanel() {
+    public GradleMultiProjectPropertiesPanel(WizardDescriptor wizard) {
+        this.wizard = wizard;
         bckgValidator = new BackgroundValidator();
 
         initComponents();
@@ -31,7 +34,7 @@ public class GradleMultiProjectPropertiesPanel extends javax.swing.JPanel {
 
         jProjectLocationEdit.setText(NewProjectUtils.getDefaultProjectDir());
 
-        Validators.connectLabelToProblems(bckgValidator, jInformationLabel);
+        Validators.connectWizardDescriptorToProblems(bckgValidator, wizard);
         NewProjectUtils.setupNewProjectValidators(bckgValidator, validators,
                 jProjectNameEdit, jProjectFolderEdit, jProjectLocationEdit);
 
@@ -104,7 +107,6 @@ public class GradleMultiProjectPropertiesPanel extends javax.swing.JPanel {
         jMavenGroupEdit = new javax.swing.JTextField();
         jMavenVersionEdit = new javax.swing.JTextField();
         jMavenVersionCaption = new javax.swing.JLabel();
-        jInformationLabel = new javax.swing.JLabel();
 
         jProjectNameCaption.setText(org.openide.util.NbBundle.getMessage(GradleMultiProjectPropertiesPanel.class, "GradleSingleProjectPropertiesPanel.jProjectNameCaption.text")); // NOI18N
 
@@ -132,8 +134,6 @@ public class GradleMultiProjectPropertiesPanel extends javax.swing.JPanel {
 
         jMavenVersionCaption.setText("Maven Version:");
 
-        jInformationLabel.setText("NO_MESSAGE");
-
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
@@ -141,26 +141,21 @@ public class GradleMultiProjectPropertiesPanel extends javax.swing.JPanel {
             .addGroup(layout.createSequentialGroup()
                 .addContainerGap()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(jProjectLocationCaption)
+                    .addComponent(jProjectNameCaption)
+                    .addComponent(jProjectFolderLocationLabel)
+                    .addComponent(jMavenGroupCaption)
+                    .addComponent(jMavenVersionCaption))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(jProjectNameEdit)
+                    .addComponent(jProjectFolderEdit, javax.swing.GroupLayout.Alignment.TRAILING)
                     .addGroup(layout.createSequentialGroup()
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(jProjectLocationCaption)
-                            .addComponent(jProjectNameCaption)
-                            .addComponent(jProjectFolderLocationLabel)
-                            .addComponent(jMavenGroupCaption)
-                            .addComponent(jMavenVersionCaption))
+                        .addComponent(jProjectLocationEdit, javax.swing.GroupLayout.DEFAULT_SIZE, 337, Short.MAX_VALUE)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(jProjectNameEdit)
-                            .addComponent(jProjectFolderEdit, javax.swing.GroupLayout.Alignment.TRAILING)
-                            .addGroup(layout.createSequentialGroup()
-                                .addComponent(jProjectLocationEdit, javax.swing.GroupLayout.DEFAULT_SIZE, 337, Short.MAX_VALUE)
-                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addComponent(jBrowseButton))
-                            .addComponent(jMavenGroupEdit)
-                            .addComponent(jMavenVersionEdit)))
-                    .addGroup(layout.createSequentialGroup()
-                        .addComponent(jInformationLabel)
-                        .addGap(0, 0, Short.MAX_VALUE)))
+                        .addComponent(jBrowseButton))
+                    .addComponent(jMavenGroupEdit)
+                    .addComponent(jMavenVersionEdit))
                 .addContainerGap())
         );
         layout.setVerticalGroup(
@@ -187,9 +182,7 @@ public class GradleMultiProjectPropertiesPanel extends javax.swing.JPanel {
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jMavenVersionEdit, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(jMavenVersionCaption))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 30, Short.MAX_VALUE)
-                .addComponent(jInformationLabel)
-                .addContainerGap())
+                .addContainerGap(52, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 
@@ -199,7 +192,6 @@ public class GradleMultiProjectPropertiesPanel extends javax.swing.JPanel {
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton jBrowseButton;
-    private javax.swing.JLabel jInformationLabel;
     private javax.swing.JLabel jMavenGroupCaption;
     private javax.swing.JTextField jMavenGroupEdit;
     private javax.swing.JLabel jMavenVersionCaption;

--- a/src/main/java/org/netbeans/gradle/project/newproject/GradleMultiProjectWizardIterator.java
+++ b/src/main/java/org/netbeans/gradle/project/newproject/GradleMultiProjectWizardIterator.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.swing.JComponent;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.annotations.common.StaticResource;
 import org.netbeans.api.java.platform.JavaPlatform;
@@ -114,7 +115,12 @@ implements
         uninitialize(wizard);
 
         descriptorIndex = 0;
-        descriptors.add(new GradleMultiProjectConfigPanel(configRef));
+        descriptors.add(new GradleMultiProjectConfigPanel(configRef, wizard));
+        wizard.putProperty ("NewProjectWizard_Title", "Gradle Project"); // NOI18N
+        JComponent c = (JComponent) descriptors.get(0).getComponent();
+        c.putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, 0);
+        c.putClientProperty(WizardDescriptor.PROP_CONTENT_DATA, new String[] {"Name and Location"});
+        c.setName("Name and Location");
     }
 
     @Override

--- a/src/main/java/org/netbeans/gradle/project/newproject/GradleSingleProjectConfigPanel.java
+++ b/src/main/java/org/netbeans/gradle/project/newproject/GradleSingleProjectConfigPanel.java
@@ -9,18 +9,20 @@ import org.openide.util.HelpCtx;
 public final class GradleSingleProjectConfigPanel implements WizardDescriptor.Panel<WizardDescriptor> {
     private final AtomicReference<GradleSingleProjectPropertiesPanel> panel;
     private final AtomicReference<GradleSingleProjectConfig> configRef;
+    private final WizardDescriptor wizard;
 
-    public GradleSingleProjectConfigPanel(AtomicReference<GradleSingleProjectConfig> configRef) {
+    public GradleSingleProjectConfigPanel(AtomicReference<GradleSingleProjectConfig> configRef, WizardDescriptor wizard) {
         if (configRef == null) throw new NullPointerException("configRef");
 
         this.configRef = configRef;
+        this.wizard = wizard;
         this.panel = new AtomicReference<GradleSingleProjectPropertiesPanel>();
     }
 
     private GradleSingleProjectPropertiesPanel getPanel() {
         GradleSingleProjectPropertiesPanel result = panel.get();
         if (result == null) {
-            panel.compareAndSet(null, new GradleSingleProjectPropertiesPanel());
+            panel.compareAndSet(null, new GradleSingleProjectPropertiesPanel(wizard));
             result = panel.get();
         }
         return result;

--- a/src/main/java/org/netbeans/gradle/project/newproject/GradleSingleProjectPropertiesPanel.form
+++ b/src/main/java/org/netbeans/gradle/project/newproject/GradleSingleProjectPropertiesPanel.form
@@ -42,10 +42,6 @@
                           <Component id="jMainClassEdit" alignment="0" max="32767" attributes="0"/>
                       </Group>
                   </Group>
-                  <Group type="102" alignment="0" attributes="0">
-                      <Component id="jInformationLabel" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
-                  </Group>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
@@ -75,9 +71,7 @@
                   <Component id="jMainClassLabel" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="jMainClassEdit" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace pref="27" max="32767" attributes="0"/>
-              <Component id="jInformationLabel" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
+              <EmptySpace pref="49" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -147,13 +141,6 @@
       <Properties>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/gradle/project/newproject/Bundle.properties" key="GradleSingleProjectPropertiesPanel.jMainClassEdit.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
-        </Property>
-      </Properties>
-    </Component>
-    <Component class="javax.swing.JLabel" name="jInformationLabel">
-      <Properties>
-        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
-          <ResourceString bundle="org/netbeans/gradle/project/newproject/Bundle.properties" key="GradleSingleProjectPropertiesPanel.jInformationLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
     </Component>

--- a/src/main/java/org/netbeans/gradle/project/newproject/GradleSingleProjectPropertiesPanel.java
+++ b/src/main/java/org/netbeans/gradle/project/newproject/GradleSingleProjectPropertiesPanel.java
@@ -8,17 +8,20 @@ import org.netbeans.gradle.project.validate.BackgroundValidator;
 import org.netbeans.gradle.project.validate.GroupValidator;
 import org.netbeans.gradle.project.validate.Validator;
 import org.netbeans.gradle.project.validate.Validators;
+import org.openide.WizardDescriptor;
 
 @SuppressWarnings("serial")
 public final class GradleSingleProjectPropertiesPanel extends javax.swing.JPanel {
     private final GroupValidator validators;
     private final BackgroundValidator bckgValidator;
+    private final WizardDescriptor wizard;
 
     /**
      * Creates new form GradleSingleProjectPropertiesPanel
      */
-    public GradleSingleProjectPropertiesPanel() {
+    public GradleSingleProjectPropertiesPanel(WizardDescriptor wizard) {
         bckgValidator = new BackgroundValidator();
+        this.wizard = wizard;
 
         initComponents();
 
@@ -29,7 +32,7 @@ public final class GradleSingleProjectPropertiesPanel extends javax.swing.JPanel
 
         jProjectLocationEdit.setText(NewProjectUtils.getDefaultProjectDir());
 
-        Validators.connectLabelToProblems(bckgValidator, jInformationLabel);
+        Validators.connectWizardDescriptorToProblems(bckgValidator, wizard);
         NewProjectUtils.setupNewProjectValidators(bckgValidator, validators,
                 jProjectNameEdit, jProjectFolderEdit, jProjectLocationEdit);
 
@@ -108,7 +111,6 @@ public final class GradleSingleProjectPropertiesPanel extends javax.swing.JPanel
         jProjectFolderEdit = new javax.swing.JTextField();
         jMainClassLabel = new javax.swing.JLabel();
         jMainClassEdit = new javax.swing.JTextField();
-        jInformationLabel = new javax.swing.JLabel();
 
         org.openide.awt.Mnemonics.setLocalizedText(jProjectNameCaption, org.openide.util.NbBundle.getMessage(GradleSingleProjectPropertiesPanel.class, "GradleSingleProjectPropertiesPanel.jProjectNameCaption.text")); // NOI18N
 
@@ -134,8 +136,6 @@ public final class GradleSingleProjectPropertiesPanel extends javax.swing.JPanel
 
         jMainClassEdit.setText(org.openide.util.NbBundle.getMessage(GradleSingleProjectPropertiesPanel.class, "GradleSingleProjectPropertiesPanel.jMainClassEdit.text")); // NOI18N
 
-        org.openide.awt.Mnemonics.setLocalizedText(jInformationLabel, org.openide.util.NbBundle.getMessage(GradleSingleProjectPropertiesPanel.class, "GradleSingleProjectPropertiesPanel.jInformationLabel.text")); // NOI18N
-
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
@@ -160,10 +160,7 @@ public final class GradleSingleProjectPropertiesPanel extends javax.swing.JPanel
                                 .addComponent(jProjectLocationEdit)
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                 .addComponent(jBrowseButton))
-                            .addComponent(jMainClassEdit)))
-                    .addGroup(layout.createSequentialGroup()
-                        .addComponent(jInformationLabel)
-                        .addGap(0, 0, Short.MAX_VALUE)))
+                            .addComponent(jMainClassEdit))))
                 .addContainerGap())
         );
         layout.setVerticalGroup(
@@ -186,9 +183,7 @@ public final class GradleSingleProjectPropertiesPanel extends javax.swing.JPanel
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jMainClassLabel)
                     .addComponent(jMainClassEdit, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 27, Short.MAX_VALUE)
-                .addComponent(jInformationLabel)
-                .addContainerGap())
+                .addContainerGap(49, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 
@@ -198,7 +193,6 @@ public final class GradleSingleProjectPropertiesPanel extends javax.swing.JPanel
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton jBrowseButton;
-    private javax.swing.JLabel jInformationLabel;
     private javax.swing.JTextField jMainClassEdit;
     private javax.swing.JLabel jMainClassLabel;
     private javax.swing.JTextField jProjectFolderEdit;

--- a/src/main/java/org/netbeans/gradle/project/newproject/GradleSingleProjectWizardIterator.java
+++ b/src/main/java/org/netbeans/gradle/project/newproject/GradleSingleProjectWizardIterator.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.swing.JComponent;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.annotations.common.StaticResource;
 import org.netbeans.api.java.platform.JavaPlatform;
@@ -104,7 +105,13 @@ implements
         uninitialize(wizard);
 
         descriptorIndex = 0;
-        descriptors.add(new GradleSingleProjectConfigPanel(configRef));
+        descriptors.add(new GradleSingleProjectConfigPanel(configRef, wizard));
+        wizard.putProperty ("NewProjectWizard_Title", "Gradle Single Project"); // NOI18N
+        JComponent c = (JComponent) descriptors.get(0).getComponent();
+        c.putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, 0);
+        c.putClientProperty(WizardDescriptor.PROP_CONTENT_DATA, new String[] {"Name and Location"});
+        c.setName("Name and Location");
+        
     }
 
     @Override

--- a/src/main/java/org/netbeans/gradle/project/newproject/GradleSubProjectConfigPanel.java
+++ b/src/main/java/org/netbeans/gradle/project/newproject/GradleSubProjectConfigPanel.java
@@ -13,11 +13,13 @@ import org.openide.util.HelpCtx;
 public final class GradleSubProjectConfigPanel implements WizardDescriptor.Panel<WizardDescriptor> {
     private final AtomicReference<GradleSingleProjectPropertiesPanel> panel;
     private final AtomicReference<GradleSingleProjectConfig> configRef;
+    private final WizardDescriptor wizard;
 
-    public GradleSubProjectConfigPanel(AtomicReference<GradleSingleProjectConfig> configRef) {
+    public GradleSubProjectConfigPanel(AtomicReference<GradleSingleProjectConfig> configRef, WizardDescriptor wizard) {
         if (configRef == null) throw new NullPointerException("configRef");
 
         this.configRef = configRef;
+        this.wizard = wizard;
         this.panel = new AtomicReference<GradleSingleProjectPropertiesPanel>();
     }
 
@@ -25,7 +27,7 @@ public final class GradleSubProjectConfigPanel implements WizardDescriptor.Panel
         GradleSingleProjectPropertiesPanel result = panel.get();
         if (result == null) {
             GradleSingleProjectPropertiesPanel newPanel
-                    = new GradleSingleProjectPropertiesPanel();
+                    = new GradleSingleProjectPropertiesPanel(wizard);
             if (panel.compareAndSet(null, newPanel)) {
                 newPanel.addProjectLocationValidator(new Validator<String>() {
                     private Problem checkFile(File projectDir, String fileName) {

--- a/src/main/java/org/netbeans/gradle/project/newproject/GradleSubProjectWizardIterator.java
+++ b/src/main/java/org/netbeans/gradle/project/newproject/GradleSubProjectWizardIterator.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.swing.JComponent;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.annotations.common.StaticResource;
 import org.netbeans.api.templates.TemplateRegistration;
@@ -101,7 +102,12 @@ implements
         uninitialize(wizard);
 
         descriptorIndex = 0;
-        descriptors.add(new GradleSubProjectConfigPanel(configRef));
+        descriptors.add(new GradleSubProjectConfigPanel(configRef, wizard));
+        wizard.putProperty ("NewProjectWizard_Title", "Gradle Subproject"); // NOI18N
+        JComponent c = (JComponent) descriptors.get(0).getComponent();
+        c.putClientProperty(WizardDescriptor.PROP_CONTENT_SELECTED_INDEX, 0);
+        c.putClientProperty(WizardDescriptor.PROP_CONTENT_DATA, new String[] {"Name and Location"});
+        c.setName("Name and Location");
     }
 
     @Override

--- a/src/main/java/org/netbeans/gradle/project/validate/Validators.java
+++ b/src/main/java/org/netbeans/gradle/project/validate/Validators.java
@@ -8,6 +8,7 @@ import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.text.JTextComponent;
 import org.netbeans.gradle.project.NbStrings;
+import org.openide.WizardDescriptor;
 
 public final class Validators {
     private static final Pattern LEGAL_FILENAME_PATTERN = Pattern.compile("[^/./\\:*?\"<>|]*");
@@ -133,5 +134,45 @@ public final class Validators {
                 }
             }
         });
+    }
+        
+    public static void connectWizardDescriptorToProblems(
+            final BackgroundValidator validator,
+            final WizardDescriptor wizard) {
+        if (validator == null) throw new NullPointerException("validator");
+        if (wizard == null) throw new NullPointerException("wizard");
+
+        wizard.putProperty(WizardDescriptor.PROP_ERROR_MESSAGE, null);
+        validator.addChangeListener(new ChangeListener() {
+            @Override
+            public void stateChanged(ChangeEvent e) {
+                Problem currentProblem = validator.getCurrentProblem();
+                String message = currentProblem != null
+                        ? currentProblem.getMessage()
+                        : "";
+                if (message.isEmpty()) {
+                    wizard.putProperty(WizardDescriptor.PROP_ERROR_MESSAGE, null);
+                }
+                else {
+                    assert currentProblem != null;
+                    String level;
+                    switch (currentProblem.getLevel()) {
+                        case INFO:
+                            level = WizardDescriptor.PROP_INFO_MESSAGE;
+                            break;
+                        case WARNING:
+                            level = WizardDescriptor.PROP_WARNING_MESSAGE;
+                            break;
+                        case SEVERE:
+                            level = WizardDescriptor.PROP_ERROR_MESSAGE;
+                            break;
+                        default:
+                            throw new AssertionError(currentProblem.getLevel().name());
+                    }
+                    wizard.putProperty(level, message);
+                }
+            }
+        });
+        
     }
 }

--- a/src/main/resources/org/netbeans/gradle/project/newproject/Bundle.properties
+++ b/src/main/resources/org/netbeans/gradle/project/newproject/Bundle.properties
@@ -7,7 +7,6 @@ GradleSingleProjectPropertiesPanel.jProjectFolderEdit.text=
 GradleSingleProjectPropertiesPanel.jMainClassLabel.text=Main Class:
 GradleSingleProjectPropertiesPanel.jMainClassEdit.text=
 GradleSingleProjectPropertiesPanel.jProjectLocationEdit.text=
-GradleSingleProjectPropertiesPanel.jInformationLabel.text=NO_TEXT
 
 MSG_InvalidPath=Invalid path.
 MSG_DirectoryAlreadyExists=Directory already exists.


### PR DESCRIPTION
please apply this changeset that attempts to clean up the ui of new gradle project wizards - https://github.com/kelemen/netbeans-gradle-project/issues/68
1. titles everywhere
2. error reporting via wizard api, removed the extra label.
