### PR TITLE
Adjust layout of project wizard and change default project location

### DIFF
--- a/src/main/java/org/netbeans/gradle/project/newproject/GradleMultiProjectPropertiesPanel.form
+++ b/src/main/java/org/netbeans/gradle/project/newproject/GradleMultiProjectPropertiesPanel.form
@@ -16,8 +16,7 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" attributes="0">
-              <EmptySpace max="-2" attributes="0"/>
+          <Group type="102" alignment="0" attributes="0">
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="jProjectLocationCaption" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Component id="jProjectNameCaption" alignment="0" min="-2" max="-2" attributes="0"/>
@@ -25,37 +24,34 @@
                   <Component id="jMavenGroupCaption" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Component id="jMavenVersionCaption" alignment="0" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace max="-2" attributes="0"/>
+              <EmptySpace min="-2" pref="6" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="jProjectNameEdit" max="32767" attributes="0"/>
-                  <Component id="jProjectFolderEdit" alignment="1" max="32767" attributes="0"/>
-                  <Group type="102" alignment="0" attributes="0">
-                      <Component id="jProjectLocationEdit" pref="337" max="32767" attributes="0"/>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Component id="jBrowseButton" min="-2" max="-2" attributes="0"/>
-                  </Group>
-                  <Component id="jMavenGroupEdit" alignment="0" max="32767" attributes="0"/>
                   <Component id="jMavenVersionEdit" alignment="0" max="32767" attributes="0"/>
+                  <Component id="jProjectNameEdit" alignment="0" max="32767" attributes="0"/>
+                  <Component id="jMavenGroupEdit" alignment="0" max="32767" attributes="0"/>
+                  <Component id="jProjectLocationEdit" alignment="0" pref="354" max="32767" attributes="0"/>
+                  <Component id="jProjectFolderEdit" alignment="0" max="32767" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
+              <Component id="jBrowseButton" min="-2" max="-2" attributes="0"/>
+              <EmptySpace min="0" pref="0" max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
-              <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="jProjectNameCaption" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="jProjectNameEdit" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="jProjectLocationCaption" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="jProjectLocationEdit" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="jBrowseButton" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="jProjectFolderEdit" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="jProjectFolderLocationLabel" alignment="3" min="-2" max="-2" attributes="0"/>
@@ -65,12 +61,11 @@
                   <Component id="jMavenGroupEdit" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="jMavenGroupCaption" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="jMavenVersionEdit" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="jMavenVersionCaption" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace pref="52" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -123,6 +118,7 @@
     </Component>
     <Component class="javax.swing.JTextField" name="jProjectFolderEdit">
       <Properties>
+        <Property name="editable" type="boolean" value="false"/>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="org/netbeans/gradle/project/newproject/Bundle.properties" key="GradleSingleProjectPropertiesPanel.jProjectFolderEdit.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
@@ -131,7 +127,7 @@
     </Component>
     <Component class="javax.swing.JLabel" name="jMavenGroupCaption">
       <Properties>
-        <Property name="text" type="java.lang.String" value="Maven GroupId:"/>
+        <Property name="text" type="java.lang.String" value="Maven Group Id:"/>
       </Properties>
     </Component>
     <Component class="javax.swing.JTextField" name="jMavenGroupEdit">

--- a/src/main/java/org/netbeans/gradle/project/newproject/GradleMultiProjectPropertiesPanel.java
+++ b/src/main/java/org/netbeans/gradle/project/newproject/GradleMultiProjectPropertiesPanel.java
@@ -32,7 +32,7 @@ public class GradleMultiProjectPropertiesPanel extends javax.swing.JPanel {
                 NewProjectUtils.createVersionValidator(),
                 Validators.createCollector(jMavenVersionEdit));
 
-        jProjectLocationEdit.setText(NewProjectUtils.getDefaultProjectDir());
+        jProjectLocationEdit.setText(NewProjectUtils.getDefaultProjectDir(wizard));
 
         Validators.connectWizardDescriptorToProblems(bckgValidator, wizard);
         NewProjectUtils.setupNewProjectValidators(bckgValidator, validators,
@@ -125,10 +125,11 @@ public class GradleMultiProjectPropertiesPanel extends javax.swing.JPanel {
 
         jProjectFolderLocationLabel.setText(org.openide.util.NbBundle.getMessage(GradleMultiProjectPropertiesPanel.class, "GradleSingleProjectPropertiesPanel.jProjectFolderLocationLabel.text")); // NOI18N
 
+        jProjectFolderEdit.setEditable(false);
         jProjectFolderEdit.setText(org.openide.util.NbBundle.getMessage(GradleMultiProjectPropertiesPanel.class, "GradleSingleProjectPropertiesPanel.jProjectFolderEdit.text")); // NOI18N
         jProjectFolderEdit.setEnabled(false);
 
-        jMavenGroupCaption.setText("Maven GroupId:");
+        jMavenGroupCaption.setText("Maven Group Id:");
 
         jMavenVersionEdit.setText("1.0-SNAPSHOT");
 
@@ -139,38 +140,35 @@ public class GradleMultiProjectPropertiesPanel extends javax.swing.JPanel {
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
-                .addContainerGap()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(jProjectLocationCaption)
                     .addComponent(jProjectNameCaption)
                     .addComponent(jProjectFolderLocationLabel)
                     .addComponent(jMavenGroupCaption)
                     .addComponent(jMavenVersionCaption))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGap(6, 6, 6)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(jMavenVersionEdit)
                     .addComponent(jProjectNameEdit)
-                    .addComponent(jProjectFolderEdit, javax.swing.GroupLayout.Alignment.TRAILING)
-                    .addGroup(layout.createSequentialGroup()
-                        .addComponent(jProjectLocationEdit, javax.swing.GroupLayout.DEFAULT_SIZE, 337, Short.MAX_VALUE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(jBrowseButton))
                     .addComponent(jMavenGroupEdit)
-                    .addComponent(jMavenVersionEdit))
-                .addContainerGap())
+                    .addComponent(jProjectLocationEdit, javax.swing.GroupLayout.DEFAULT_SIZE, 354, Short.MAX_VALUE)
+                    .addComponent(jProjectFolderEdit))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(jBrowseButton)
+                .addGap(0, 0, 0))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
-                .addContainerGap()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jProjectNameCaption)
                     .addComponent(jProjectNameEdit, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jProjectLocationCaption)
                     .addComponent(jProjectLocationEdit, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(jBrowseButton))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jProjectFolderEdit, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(jProjectFolderLocationLabel))
@@ -178,11 +176,10 @@ public class GradleMultiProjectPropertiesPanel extends javax.swing.JPanel {
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jMavenGroupEdit, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(jMavenGroupCaption))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jMavenVersionEdit, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jMavenVersionCaption))
-                .addContainerGap(52, Short.MAX_VALUE))
+                    .addComponent(jMavenVersionCaption)))
         );
     }// </editor-fold>//GEN-END:initComponents
 

--- a/src/main/java/org/netbeans/gradle/project/newproject/GradleSingleProjectPropertiesPanel.form
+++ b/src/main/java/org/netbeans/gradle/project/newproject/GradleSingleProjectPropertiesPanel.form
@@ -17,45 +17,32 @@
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" attributes="0">
-              <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Group type="102" alignment="1" attributes="0">
-                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
-                      <Component id="jProjectNameCaption" min="-2" max="-2" attributes="0"/>
-                      <EmptySpace type="separate" max="-2" attributes="0"/>
-                      <Component id="jProjectNameEdit" min="-2" pref="409" max="-2" attributes="0"/>
-                  </Group>
-                  <Group type="102" alignment="0" attributes="0">
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="jProjectLocationCaption" min="-2" max="-2" attributes="0"/>
-                          <Component id="jProjectFolderLocationLabel" alignment="0" min="-2" max="-2" attributes="0"/>
-                          <Component id="jMainClassLabel" alignment="0" min="-2" max="-2" attributes="0"/>
-                      </Group>
-                      <EmptySpace max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="jProjectFolderEdit" alignment="1" max="32767" attributes="0"/>
-                          <Group type="102" alignment="1" attributes="0">
-                              <Component id="jProjectLocationEdit" max="32767" attributes="0"/>
-                              <EmptySpace max="-2" attributes="0"/>
-                              <Component id="jBrowseButton" min="-2" max="-2" attributes="0"/>
-                          </Group>
-                          <Component id="jMainClassEdit" alignment="0" max="32767" attributes="0"/>
-                      </Group>
-                  </Group>
+                  <Component id="jProjectNameCaption" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="jMainClassLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="jProjectLocationCaption" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="jProjectFolderLocationLabel" alignment="0" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace max="-2" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="jProjectNameEdit" alignment="0" pref="316" max="32767" attributes="0"/>
+                  <Component id="jMainClassEdit" alignment="0" max="32767" attributes="0"/>
+                  <Component id="jProjectLocationEdit" alignment="0" max="32767" attributes="0"/>
+                  <Component id="jProjectFolderEdit" alignment="0" max="32767" attributes="0"/>
+              </Group>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
+              <Component id="jBrowseButton" min="-2" max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
-              <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="jProjectNameCaption" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="jProjectNameEdit" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="jProjectLocationCaption" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="jProjectLocationEdit" alignment="3" min="-2" max="-2" attributes="0"/>
@@ -71,7 +58,6 @@
                   <Component id="jMainClassLabel" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="jMainClassEdit" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace pref="49" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>

--- a/src/main/java/org/netbeans/gradle/project/newproject/GradleSingleProjectPropertiesPanel.java
+++ b/src/main/java/org/netbeans/gradle/project/newproject/GradleSingleProjectPropertiesPanel.java
@@ -12,6 +12,7 @@ import org.openide.WizardDescriptor;
 
 @SuppressWarnings("serial")
 public final class GradleSingleProjectPropertiesPanel extends javax.swing.JPanel {
+
     private final GroupValidator validators;
     private final BackgroundValidator bckgValidator;
     private final WizardDescriptor wizard;
@@ -30,7 +31,7 @@ public final class GradleSingleProjectPropertiesPanel extends javax.swing.JPanel
                 NewProjectUtils.createClassNameValidator(true),
                 Validators.createCollector(jMainClassEdit));
 
-        jProjectLocationEdit.setText(NewProjectUtils.getDefaultProjectDir());
+        jProjectLocationEdit.setText(NewProjectUtils.getDefaultProjectDir(wizard));
 
         Validators.connectWizardDescriptorToProblems(bckgValidator, wizard);
         NewProjectUtils.setupNewProjectValidators(bckgValidator, validators,
@@ -77,7 +78,9 @@ public final class GradleSingleProjectPropertiesPanel extends javax.swing.JPanel
         String projectName = jProjectNameEdit.getText().trim();
         String projectDirStr = jProjectFolderEdit.getText().trim();
         String mainClass = jMainClassEdit.getText().trim();
-        if (mainClass.isEmpty()) mainClass = null;
+        if (mainClass.isEmpty()) {
+            mainClass = null;
+        }
 
         if (projectName.isEmpty() || projectDirStr.isEmpty()) {
             return null;
@@ -141,36 +144,27 @@ public final class GradleSingleProjectPropertiesPanel extends javax.swing.JPanel
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
-                .addContainerGap()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
-                        .addGap(0, 0, Short.MAX_VALUE)
-                        .addComponent(jProjectNameCaption)
-                        .addGap(18, 18, 18)
-                        .addComponent(jProjectNameEdit, javax.swing.GroupLayout.PREFERRED_SIZE, 409, javax.swing.GroupLayout.PREFERRED_SIZE))
-                    .addGroup(layout.createSequentialGroup()
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(jProjectLocationCaption)
-                            .addComponent(jProjectFolderLocationLabel)
-                            .addComponent(jMainClassLabel))
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(jProjectFolderEdit, javax.swing.GroupLayout.Alignment.TRAILING)
-                            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
-                                .addComponent(jProjectLocationEdit)
-                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addComponent(jBrowseButton))
-                            .addComponent(jMainClassEdit))))
-                .addContainerGap())
+                    .addComponent(jProjectNameCaption)
+                    .addComponent(jMainClassLabel)
+                    .addComponent(jProjectLocationCaption)
+                    .addComponent(jProjectFolderLocationLabel))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(jProjectNameEdit, javax.swing.GroupLayout.DEFAULT_SIZE, 316, Short.MAX_VALUE)
+                    .addComponent(jMainClassEdit)
+                    .addComponent(jProjectLocationEdit)
+                    .addComponent(jProjectFolderEdit))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addComponent(jBrowseButton))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
-                .addContainerGap()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jProjectNameCaption)
                     .addComponent(jProjectNameEdit, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jProjectLocationCaption)
                     .addComponent(jProjectLocationEdit, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
@@ -182,8 +176,7 @@ public final class GradleSingleProjectPropertiesPanel extends javax.swing.JPanel
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jMainClassLabel)
-                    .addComponent(jMainClassEdit, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addContainerGap(49, Short.MAX_VALUE))
+                    .addComponent(jMainClassEdit, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))
         );
     }// </editor-fold>//GEN-END:initComponents
 

--- a/src/main/java/org/netbeans/gradle/project/newproject/NewProjectUtils.java
+++ b/src/main/java/org/netbeans/gradle/project/newproject/NewProjectUtils.java
@@ -24,6 +24,8 @@ import org.openide.util.NbPreferences;
 import org.openide.util.Utilities;
 
 import static org.netbeans.gradle.project.validate.Validators.*;
+import org.netbeans.spi.project.ui.support.ProjectChooser;
+import org.openide.WizardDescriptor;
 
 public final class NewProjectUtils {
     public static final Charset DEFAULT_FILE_ENCODING = Charset.forName("UTF-8");
@@ -52,12 +54,16 @@ public final class NewProjectUtils {
         StringUtils.writeStringToFile(resourceContent, encoding, destination);
     }
 
-    public static String getDefaultProjectDir() {
-        String defaultDir = NewProjectUtils.getPreferences().get(DEFAULT_PROJECTDIR_SETTINGS_KEY, "");
-        if (defaultDir.isEmpty()) {
-            defaultDir = new File(System.getProperty("user.home"), "Projects").getAbsolutePath();
+    public static String getDefaultProjectDir(WizardDescriptor settings) {
+        // TODO: CommonProjectActions.PROJECT_PARENT_FOLDER is not availbale on NetBeans 7.2?
+        // File projectLocation = (File) settings.getProperty(CommonProjectActions.PROJECT_PARENT_FOLDER); //NOI18N
+        File projectLocation = (File) settings.getProperty("projdir"); //NOI18N
+        if (projectLocation == null || projectLocation.getParentFile() == null
+                || !projectLocation.getParentFile().isDirectory()) {
+            projectLocation = ProjectChooser.getProjectsFolder();
         }
-        return defaultDir;
+        
+        return projectLocation.getAbsolutePath();
     }
 
     public static void setDefaultProjectDir(String newValue) {

--- a/src/main/resources/org/netbeans/gradle/project/newproject/Bundle.properties
+++ b/src/main/resources/org/netbeans/gradle/project/newproject/Bundle.properties
@@ -1,7 +1,7 @@
 GradleSingleProjectPropertiesPanel.jProjectNameCaption.text=Project Name:
 GradleSingleProjectPropertiesPanel.jProjectNameEdit.text=
 GradleSingleProjectPropertiesPanel.jProjectLocationCaption.text=Project Location:
-GradleSingleProjectPropertiesPanel.jBrowseButton.text=Browse
+GradleSingleProjectPropertiesPanel.jBrowseButton.text=Browse...
 GradleSingleProjectPropertiesPanel.jProjectFolderLocationLabel.text=Project Folder:
 GradleSingleProjectPropertiesPanel.jProjectFolderEdit.text=
 GradleSingleProjectPropertiesPanel.jMainClassLabel.text=Main Class:


### PR DESCRIPTION
- Mimic layout of NetBeans default project layout to make a uniform look across all the supported project.
- Update project location to the NetBeans default project location.
- Update Single Project's browse button label.
