### PR TITLE
Handle <skipped/> elements in test results.

### DIFF
--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/java/test/TestXmlDisplayer.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/java/test/TestXmlDisplayer.java
@@ -356,6 +356,10 @@ public final class TestXmlDisplayer {
                         error = true;
                         testcase.setStatus(Status.ERROR);
                         break;
+                    case "skipped":
+                        error = false;
+                        testcase.setStatus(Status.SKIPPED);
+                        break;
                     default:
                         LOGGER.log(Level.WARNING, "Unexpected element in testcase: {0}", qName);
                         error = true;


### PR DESCRIPTION
Skipped test cases (e.g. ones that `assumeThat` do not hold) were marked as errors in the NetBeans test result window (Alt+F6). This PR fixes that.
