### PR TITLE
ProjectLookupHack now use type names instead of class instances

### DIFF
--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/ProjectLookupHack.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/ProjectLookupHack.java
@@ -12,12 +12,14 @@ import java.util.logging.Logger;
 import org.jtrim.utils.ExceptionHelper;
 import org.netbeans.api.java.classpath.ClassPath;
 import org.netbeans.api.project.ProjectInformation;
+import org.netbeans.gradle.project.java.JavaExtension;
 import org.netbeans.gradle.project.properties.NbGradleSingleProjectConfigProvider;
 import org.netbeans.spi.java.classpath.ClassPathProvider;
 import org.netbeans.spi.project.ActionProvider;
 import org.netbeans.spi.project.ProjectConfigurationProvider;
 import org.netbeans.spi.project.SubprojectProvider;
 import org.netbeans.spi.project.ui.CustomizerProvider;
+import org.netbeans.spi.queries.SharabilityQueryImplementation2;
 import org.openide.filesystems.FileObject;
 import org.openide.util.Lookup;
 import org.openide.util.lookup.Lookups;
@@ -80,25 +82,29 @@ public final class ProjectLookupHack extends ProxyLookup {
     }
 
     private class AccessPreventerLookup extends Lookup {
-        private final Map<Class<?>, Lookup> typeActions;
+        private final Map<String, Lookup> typeActions;
 
         public AccessPreventerLookup() {
             this.typeActions = new HashMap<>();
             for (Class<?> type: getNotImplementedServices()) {
-                typeActions.put(type, Lookup.EMPTY);
+                typeActions.put(type.getName(), Lookup.EMPTY);
             }
-            typeActions.put(ClassPathProvider.class, Lookups.singleton(new UnimportantRootClassPathProvider()));
+            typeActions.put(ClassPathProvider.class.getName(), Lookups.singleton(new UnimportantRootClassPathProvider()));
 
             Lookup wrappedLookup = lookupContainer.getLookup();
-            typeActions.put(ProjectInformation.class, wrappedLookup);
-            typeActions.put(ActionProvider.class, wrappedLookup);
-            typeActions.put(CustomizerProvider.class, wrappedLookup);
-            typeActions.put(NbGradleSingleProjectConfigProvider.class, wrappedLookup);
-            typeActions.put(ProjectConfigurationProvider.class, wrappedLookup);
+            typeActions.put(ProjectInformation.class.getName(), wrappedLookup);
+            typeActions.put(ActionProvider.class.getName(), wrappedLookup);
+            typeActions.put(CustomizerProvider.class.getName(), wrappedLookup);
+            typeActions.put(NbGradleSingleProjectConfigProvider.class.getName(), wrappedLookup);
+            typeActions.put(ProjectConfigurationProvider.class.getName(), wrappedLookup);
+            typeActions.put(JavaExtension.class.getName(), wrappedLookup);
+            typeActions.put(SharabilityQueryImplementation2.class.getName(), wrappedLookup);
+            typeActions.put("org.netbeans.modules.maven.NbMavenProjectImpl", wrappedLookup);
+            typeActions.put("org.netbeans.modules.web.browser.spi.ProjectBrowserProvider", wrappedLookup);
         }
 
         private Lookup lookupForType(Class<?> type) {
-            Lookup action = typeActions.get(type);
+            Lookup action = typeActions.get(type.getName());
             if (action != null) {
                 LOGGER.log(Level.INFO, "Using custom lookup for type {0}", type.getName());
                 return action;


### PR DESCRIPTION
Added more types to the black-list.

With my setup, browsing the Favorites view do not trigger project load when a project-folder node gets focused.
Project loading still happens if the node is unfolded.

Related to #25