### PR TITLE
Added JavaFX to the recommended templates

### DIFF
--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/java/query/GradleProjectTemplates.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/java/query/GradleProjectTemplates.java
@@ -11,6 +11,7 @@ public final class GradleProjectTemplates implements PrivilegedTemplates, Recomm
         "java-forms",
         "java-beans",
         "j2ee-types",
+        "javafx",
         "gui-java-application",
         "java-beans",
         "oasis-XML-catalogs",


### PR DESCRIPTION
Hi Attila,
this fixes the issue #160. JavaFX category will be present in the "new file" wizard.

Following changeset on the NetBeans side enables Gradle project recognition in JavaFX Project module (particulary to create FXML and CSS under project's resources):
http://hg.netbeans.org/web-main/rev/1dae1dc985d6

Patch that I commited to the NetBeans repository will be available in NetBeans 8.1 release (and dev builds until then as well). In 8.0.2 (without updated JavaFX project module) it will work too, but FXML files will be created under Java Sources.