### PR TITLE
Add missing dependency

### DIFF
--- a/netbeans-gradle-plugin/build.gradle
+++ b/netbeans-gradle-plugin/build.gradle
@@ -127,6 +127,7 @@ dependencies {
     providedCompile netbeansApi('org-netbeans-modules-options-api')
     providedCompile netbeansApi('org-netbeans-modules-projectapi')
     providedCompile netbeansApi('org-netbeans-modules-projectuiapi')
+    providedCompile netbeansApi('org-netbeans-modules-projectuiapi-base')
     providedCompile netbeansApi('org-netbeans-modules-queries')
     providedCompile netbeansApi('org-openide-actions')
     providedCompile netbeansApi('org-openide-awt')


### PR DESCRIPTION
 org-netbeans-modules-projectuiapi-base was missing, works for compile time but crashes during runtime