### PR TITLE
Task menu now visible when selecting multiple projects

### DIFF
--- a/netbeans-gradle-default-models/src/main/java/org/netbeans/gradle/model/GradleTaskID.java
+++ b/netbeans-gradle-default-models/src/main/java/org/netbeans/gradle/model/GradleTaskID.java
@@ -20,4 +20,13 @@ public final class GradleTaskID implements Serializable {
     public String getFullName() {
         return fullName;
     }
+    
+    @Override
+    public boolean equals(Object other) {
+        if (other instanceof GradleTaskID) {
+            GradleTaskID otherTaskId = ((GradleTaskID) other);
+            return String.valueOf(name).equals(String.valueOf(otherTaskId.name));
+        }
+        return false;
+    }
 }

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/actions/BuildAction.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/actions/BuildAction.java
@@ -1,0 +1,57 @@
+package org.netbeans.gradle.project.actions;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+import org.netbeans.api.project.Project;
+import org.netbeans.gradle.project.NbGradleProject;
+import org.netbeans.spi.project.ActionProgress;
+import org.netbeans.spi.project.ActionProvider;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionRegistration;
+import org.openide.util.Mutex;
+import org.openide.util.lookup.Lookups;
+
+@ActionRegistration(
+  displayName="org.netbeans.gradle.project.Bundle#NbStrings.Build"
+)
+@ActionID(
+  category="GradleProject",
+  id="GradleBuildAction" 
+)
+@ActionReference(path="Actions/GradleProject", position = 4, separatorBefore = 3)
+public class BuildAction implements ActionListener {
+
+    private List<NbGradleProject> projects;
+
+    public BuildAction(List<NbGradleProject> projects) {
+        this.projects = projects;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        for (Project p : projects) {
+            final ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+            if (ap == null) {
+                return;
+            }
+
+            Mutex.EVENT.writeAccess(new Runnable() {
+                @Override
+                public void run() {
+                    ap.invokeAction(ActionProvider.COMMAND_BUILD, Lookups.singleton(new ActionProgress() {
+                        @Override
+                        protected void started() {
+                        }
+
+                        @Override
+                        public void finished(boolean success) {
+                        }
+                    }));
+                }
+            });
+        }
+    }
+
+}

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/actions/CleanAction.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/actions/CleanAction.java
@@ -1,0 +1,57 @@
+package org.netbeans.gradle.project.actions;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+import org.netbeans.api.project.Project;
+import org.netbeans.gradle.project.NbGradleProject;
+import org.netbeans.spi.project.ActionProgress;
+import org.netbeans.spi.project.ActionProvider;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionRegistration;
+import org.openide.util.Mutex;
+import org.openide.util.lookup.Lookups;
+
+@ActionRegistration(
+  displayName="org.netbeans.gradle.project.Bundle#NbStrings.Clean"
+)
+@ActionID(
+  category="GradleProject",
+  id="GradleCleanAction" 
+)
+@ActionReference(path="Actions/GradleProject", position = 6)
+public class CleanAction implements ActionListener {
+
+    private List<NbGradleProject> projects;
+
+    public CleanAction(List<NbGradleProject> projects) {
+        this.projects = projects;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        for (Project p : projects) {
+            final ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+            if (ap == null) {
+                return;
+            }
+
+            Mutex.EVENT.writeAccess(new Runnable() {
+                @Override
+                public void run() {
+                    ap.invokeAction(ActionProvider.COMMAND_CLEAN, Lookups.singleton(new ActionProgress() {
+                        @Override
+                        protected void started() {
+                        }
+
+                        @Override
+                        public void finished(boolean success) {
+                        }
+                    }));
+                }
+            });
+        }
+    }
+
+}

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/actions/DebugAction.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/actions/DebugAction.java
@@ -1,0 +1,57 @@
+package org.netbeans.gradle.project.actions;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+import org.netbeans.api.project.Project;
+import org.netbeans.gradle.project.NbGradleProject;
+import org.netbeans.spi.project.ActionProgress;
+import org.netbeans.spi.project.ActionProvider;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionRegistration;
+import org.openide.util.Mutex;
+import org.openide.util.lookup.Lookups;
+
+@ActionRegistration(
+  displayName="org.netbeans.gradle.project.Bundle#NbStrings.Debug"
+)
+@ActionID(
+  category="GradleProject",
+  id="GradleDebugAction" 
+)
+@ActionReference(path="Actions/GradleProject", position = 2)
+public class DebugAction implements ActionListener {
+
+    private List<NbGradleProject> projects;
+
+    public DebugAction(List<NbGradleProject> projects) {
+        this.projects = projects;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        for (Project p : projects) {
+            final ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+            if (ap == null) {
+                return;
+            }
+
+            Mutex.EVENT.writeAccess(new Runnable() {
+                @Override
+                public void run() {
+                    ap.invokeAction(ActionProvider.COMMAND_DEBUG, Lookups.singleton(new ActionProgress() {
+                        @Override
+                        protected void started() {
+                        }
+
+                        @Override
+                        public void finished(boolean success) {
+                        }
+                    }));
+                }
+            });
+        }
+    }
+
+}

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/actions/RebuildAction.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/actions/RebuildAction.java
@@ -1,0 +1,57 @@
+package org.netbeans.gradle.project.actions;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+import org.netbeans.api.project.Project;
+import org.netbeans.gradle.project.NbGradleProject;
+import org.netbeans.spi.project.ActionProgress;
+import org.netbeans.spi.project.ActionProvider;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionRegistration;
+import org.openide.util.Mutex;
+import org.openide.util.lookup.Lookups;
+
+@ActionRegistration(
+  displayName="org.netbeans.gradle.project.Bundle#NbStrings.Rebuild"
+)
+@ActionID(
+  category="GradleProject",
+  id="GradleRebuildAction" 
+)
+@ActionReference(path="Actions/GradleProject", position = 7)
+public class RebuildAction implements ActionListener {
+
+    private List<NbGradleProject> projects;
+
+    public RebuildAction(List<NbGradleProject> projects) {
+        this.projects = projects;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        for (Project p : projects) {
+            final ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+            if (ap == null) {
+                return;
+            }
+
+            Mutex.EVENT.writeAccess(new Runnable() {
+                @Override
+                public void run() {
+                    ap.invokeAction(ActionProvider.COMMAND_REBUILD, Lookups.singleton(new ActionProgress() {
+                        @Override
+                        protected void started() {
+                        }
+
+                        @Override
+                        public void finished(boolean success) {
+                        }
+                    }));
+                }
+            });
+        }
+    }
+
+}

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/actions/ReloadAction.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/actions/ReloadAction.java
@@ -1,0 +1,58 @@
+package org.netbeans.gradle.project.actions;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+import org.netbeans.api.project.Project;
+import org.netbeans.gradle.project.NbGradleProject;
+import org.netbeans.gradle.project.view.GradleActionProvider;
+import org.netbeans.spi.project.ActionProgress;
+import org.netbeans.spi.project.ActionProvider;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionRegistration;
+import org.openide.util.Mutex;
+import org.openide.util.lookup.Lookups;
+
+@ActionRegistration(
+  displayName="org.netbeans.gradle.project.Bundle#NbStrings.ReloadProject"
+)
+@ActionID(
+  category="System",
+  id="Gradle.ReloadAction" 
+)
+@ActionReference(path="Gradle")
+public class ReloadAction implements ActionListener {
+
+    private List<NbGradleProject> projects;
+
+    public ReloadAction(List<NbGradleProject> projects) {
+        this.projects = projects;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        for (Project p : projects) {
+            final ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+            if (ap == null) {
+                return;
+            }
+
+            Mutex.EVENT.writeAccess(new Runnable() {
+                @Override
+                public void run() {
+                    ap.invokeAction(GradleActionProvider.COMMAND_RELOAD, Lookups.singleton(new ActionProgress() {
+                        @Override
+                        protected void started() {
+                        }
+
+                        @Override
+                        public void finished(boolean success) {
+                        }
+                    }));
+                }
+            });
+        }
+    }
+
+}

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/actions/RunAction.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/actions/RunAction.java
@@ -1,0 +1,57 @@
+package org.netbeans.gradle.project.actions;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+import org.netbeans.api.project.Project;
+import org.netbeans.gradle.project.NbGradleProject;
+import org.netbeans.spi.project.ActionProgress;
+import org.netbeans.spi.project.ActionProvider;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionRegistration;
+import org.openide.util.Mutex;
+import org.openide.util.lookup.Lookups;
+
+@ActionRegistration(
+  displayName="org.netbeans.gradle.project.Bundle#NbStrings.Run"
+)
+@ActionID(
+  category="GradleProject",
+  id="GradleRunAction" 
+)
+@ActionReference(path="Actions/GradleProject", position = 1)
+public class RunAction implements ActionListener {
+
+    private List<NbGradleProject> projects;
+
+    public RunAction(List<NbGradleProject> projects) {
+        this.projects = projects;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        for (Project p : projects) {
+            final ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+            if (ap == null) {
+                return;
+            }
+
+            Mutex.EVENT.writeAccess(new Runnable() {
+                @Override
+                public void run() {
+                    ap.invokeAction(ActionProvider.COMMAND_RUN, Lookups.singleton(new ActionProgress() {
+                        @Override
+                        protected void started() {
+                        }
+
+                        @Override
+                        public void finished(boolean success) {
+                        }
+                    }));
+                }
+            });
+        }
+    }
+
+}

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/actions/TestAction.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/actions/TestAction.java
@@ -1,0 +1,57 @@
+package org.netbeans.gradle.project.actions;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+import org.netbeans.api.project.Project;
+import org.netbeans.gradle.project.NbGradleProject;
+import org.netbeans.spi.project.ActionProgress;
+import org.netbeans.spi.project.ActionProvider;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionRegistration;
+import org.openide.util.Mutex;
+import org.openide.util.lookup.Lookups;
+
+@ActionRegistration(
+  displayName="org.netbeans.gradle.project.Bundle#NbStrings.Test"
+)
+@ActionID(
+  category="GradleProject",
+  id="GradleTestAction" 
+)
+@ActionReference(path="Actions/GradleProject", position = 5)
+public class TestAction implements ActionListener {
+
+    private List<NbGradleProject> projects;
+
+    public TestAction(List<NbGradleProject> projects) {
+        this.projects = projects;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        for (Project p : projects) {
+            final ActionProvider ap = p.getLookup().lookup(ActionProvider.class);
+            if (ap == null) {
+                return;
+            }
+
+            Mutex.EVENT.writeAccess(new Runnable() {
+                @Override
+                public void run() {
+                    ap.invokeAction(ActionProvider.COMMAND_TEST, Lookups.singleton(new ActionProgress() {
+                        @Override
+                        protected void started() {
+                        }
+
+                        @Override
+                        public void finished(boolean success) {
+                        }
+                    }));
+                }
+            });
+        }
+    }
+
+}

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/view/GradleProjectLogicalViewProvider.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/view/GradleProjectLogicalViewProvider.java
@@ -277,35 +277,15 @@ implements
             List<Action> projectActions = new LinkedList<>();
             projectActions.add(CommonProjectActions.newFileAction());
             projectActions.add(null);
-            projectActions.add(createProjectAction(
-                    ActionProvider.COMMAND_RUN,
-                    NbStrings.getRunCommandCaption()));
-            projectActions.add(createProjectAction(
-                    ActionProvider.COMMAND_DEBUG,
-                    NbStrings.getDebugCommandCaption()));
-            projectActions.add(null);
-            projectActions.add(createProjectAction(
-                    ActionProvider.COMMAND_BUILD,
-                    NbStrings.getBuildCommandCaption()));
-            projectActions.add(createProjectAction(
-                    ActionProvider.COMMAND_TEST,
-                    NbStrings.getTestCommandCaption()));
-            projectActions.add(createProjectAction(
-                    ActionProvider.COMMAND_CLEAN,
-                    NbStrings.getCleanCommandCaption()));
-            projectActions.add(createProjectAction(
-                    ActionProvider.COMMAND_REBUILD,
-                    NbStrings.getRebuildCommandCaption()));
-
+            projectActions.addAll(Utilities.actionsForPath("Actions/GradleProject"));
+            
             ExtensionActions extActions = getExtensionActions();
             projectActions.addAll(extActions.getBuildActions());
 
             projectActions.add(customTasksAction);
             projectActions.add(tasksAction);
             projectActions.add(null);
-            projectActions.add(createProjectAction(
-                    GradleActionProvider.COMMAND_RELOAD,
-                    NbStrings.getReloadCommandCaption()));
+            projectActions.addAll(Utilities.actionsForPath("Gradle"));
             projectActions.add(NodeUtils.getRefreshNodeAction(this, NbStrings.getRefreshNodeCommandCaption()));
             projectActions.addAll(extActions.getProjectManagementActions());
             projectActions.add(CommonProjectActions.closeProjectAction());


### PR DESCRIPTION
Hi Attila, how are you doing?

This pull request is the first of 2 that i will be making. They are functionally similar, but required different approaches and work independently.

This one is about letting you access the Task menu when multiple Gradle projects are selected. The user will see a task list that is the intersection of all tasks available in the selected projects (so only tasks common to all of them them will be visible).
