### PR TITLE
${selected-file} variable should be available for tasks

### DIFF
--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/tasks/StandardTaskVariable.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/tasks/StandardTaskVariable.java
@@ -1,5 +1,6 @@
 package org.netbeans.gradle.project.tasks;
 
+import java.io.File;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -57,11 +58,16 @@ public enum StandardTaskVariable {
     SELECTED_FILE("selected-file", new ValueGetter<NbGradleProject>() {
         @Override
         public VariableValue getValue(TaskVariableMap variables, NbGradleProject project, Lookup actionContext) {
-            FileObject file = getFileOfContext(actionContext);
+            FileObject fileObject = getFileOfContext(actionContext);
+            if (fileObject == null) {
+                return VariableValue.NULL_VALUE;
+            }
+            
+            File file = FileUtil.toFile(fileObject);
             if (file == null) {
                 return VariableValue.NULL_VALUE;
             }
-
+            
             return new VariableValue(file.getPath());
         }
     }),

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/tasks/StandardTaskVariable.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/tasks/StandardTaskVariable.java
@@ -54,6 +54,17 @@ public enum StandardTaskVariable {
             return getClassNameForFile(project, file);
         }
     }),
+    SELECTED_FILE("selected-file", new ValueGetter<NbGradleProject>() {
+        @Override
+        public VariableValue getValue(TaskVariableMap variables, NbGradleProject project, Lookup actionContext) {
+            FileObject file = getFileOfContext(actionContext);
+            if (file == null) {
+                return VariableValue.NULL_VALUE;
+            }
+
+            return new VariableValue(file.getPath());
+        }
+    }),
     TEST_FILE_PATH("test-file-path", new ValueGetter<NbGradleProject>() {
         @Override
         public VariableValue getValue(TaskVariableMap variables, NbGradleProject project, Lookup actionContext) {


### PR DESCRIPTION
I needed this for testing single cucumber feature files. Current
variables don't work when a non-java file (a resource) is selected.