### PR TITLE
Fixed CompileOnSave for non-Gradle projects.

### DIFF
--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/java/tasks/CompileOnSaveAction.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/java/tasks/CompileOnSaveAction.java
@@ -48,7 +48,7 @@ public final class CompileOnSaveAction implements OnSaveTask {
     }
 
     private static boolean isGradleProject(Project project) {
-        return NbGradleProjectFactory.getGradleProject(project) != null;
+        return NbGradleProjectFactory.tryGetGradleProject(project) != null;
     }
 
     @Override


### PR DESCRIPTION
The CompileOnSave mechanism checked via getGradleProject-method if the project is a gradle-project.
It is expected to return null and thus usGradleProject would return false.
Unfortunately, IllegalStateException is thrown in this case.
Switched to tryGetGradleProject-method that actually returns null.