### PR TITLE
Add jvm args support in run/debug tasks

### DIFF
--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/java/tasks/GradleJavaBuiltInCommands.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/java/tasks/GradleJavaBuiltInCommands.java
@@ -60,6 +60,7 @@ public final class GradleJavaBuiltInCommands implements BuiltInGradleCommandQuer
 
     private static final String MAIN_CLASS_PROPERTY_NAME = "mainClass";
     private static final String CMD_LINE_ARGS_PROPERTY_NAME = "cmdLineArgs";
+    private static final String JVM_LINE_ARGS_PROPERTY_NAME = "jvmLineArgs";
     private static final String JPDA_PORT_PROPERTY_NAME = "debuggerJpdaPort";
     private static final String DEBUGGED_TASK_PROPERTY_NAME = "debuggedTaskName";
 
@@ -86,16 +87,16 @@ public final class GradleJavaBuiltInCommands implements BuiltInGradleCommandQuer
     private static final CommandWithActions DEFAULT_RUN_TASK = blockingCommand(
             TaskKind.RUN,
             Arrays.asList(projectTask("run")),
-            Arrays.asList(cmdLineArg()));
+            Arrays.asList(cmdLineArg(), jvmLineArg()));
     private static final CommandWithActions DEFAULT_DEBUG_TASK_1 = blockingCommand(
             TaskKind.DEBUG,
             Arrays.asList(projectTask("debug")),
-            Arrays.asList(cmdLineArg()),
+            Arrays.asList(cmdLineArg(), jvmLineArg()),
             attachDebugger());
     private static final CommandWithActions DEFAULT_DEBUG_TASK_2 = blockingCommand(
             TaskKind.DEBUG,
             Arrays.asList(projectTask("run")),
-            debuggeeAttachesArguments(projectTask("run"), cmdLineArg()),
+            debuggeeAttachesArguments(projectTask("run"), cmdLineArg(), jvmLineArg()),
             listenDebugger());
     private static final CommandWithActions DEFAULT_JAVADOC_TASK = nonBlockingCommand(
             TaskKind.BUILD,
@@ -173,20 +174,20 @@ public final class GradleJavaBuiltInCommands implements BuiltInGradleCommandQuer
     private static final CommandWithActions DEFAULT_RUN_SINGLE_TASK = blockingCommand(
             TaskKind.RUN,
             Arrays.asList(projectTask("run")),
-            Arrays.asList(gradlePropertyArg(MAIN_CLASS_PROPERTY_NAME, StandardTaskVariable.SELECTED_CLASS.getVariable()), cmdLineArg()),
+            Arrays.asList(gradlePropertyArg(MAIN_CLASS_PROPERTY_NAME, StandardTaskVariable.SELECTED_CLASS.getVariable()), cmdLineArg(), jvmLineArg()),
             true,
             true);
     private static final CommandWithActions DEFAULT_DEBUG_SINGLE_TASK_1 = blockingCommand(
             TaskKind.DEBUG,
             Arrays.asList(projectTask("debug")),
-            Arrays.asList(gradlePropertyArg(MAIN_CLASS_PROPERTY_NAME, StandardTaskVariable.SELECTED_CLASS.getVariable()), cmdLineArg()),
+            Arrays.asList(gradlePropertyArg(MAIN_CLASS_PROPERTY_NAME, StandardTaskVariable.SELECTED_CLASS.getVariable()), cmdLineArg(), jvmLineArg()),
             true,
             true,
             attachDebugger());
     private static final CommandWithActions DEFAULT_DEBUG_SINGLE_TASK_2 = blockingCommand(
             TaskKind.DEBUG,
             Arrays.asList(projectTask("run")),
-            debuggeeAttachesArguments(projectTask("run"), gradlePropertyArg(MAIN_CLASS_PROPERTY_NAME, StandardTaskVariable.SELECTED_CLASS.getVariable()), cmdLineArg()),
+            debuggeeAttachesArguments(projectTask("run"), gradlePropertyArg(MAIN_CLASS_PROPERTY_NAME, StandardTaskVariable.SELECTED_CLASS.getVariable()), cmdLineArg(), jvmLineArg()),
             true,
             true,
             listenDebugger());
@@ -243,6 +244,10 @@ public final class GradleJavaBuiltInCommands implements BuiltInGradleCommandQuer
 
     private static String cmdLineArg() {
         return gradlePropertyArg(CMD_LINE_ARGS_PROPERTY_NAME, StandardTaskVariable.CMD_LINE_ARGS.getVariable());
+    }
+
+    private static String jvmLineArg() {
+        return gradlePropertyArg(JVM_LINE_ARGS_PROPERTY_NAME, StandardTaskVariable.JVM_LINE_ARGS.getVariable());
     }
 
     private static String gradlePropertyArg(String propertyName, TaskVariable taskVar) {

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/tasks/vars/StandardTaskVariable.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/tasks/vars/StandardTaskVariable.java
@@ -120,9 +120,14 @@ public enum StandardTaskVariable {
                     ? StringUtils.capitalizeFirstCharacter(value)
                     : null);
         }
-    })
-    ,
+    }),
     CMD_LINE_ARGS("cmd-line-args", new ValueGetter<NbGradleProject>() {
+        @Override
+        public VariableValue getValue(TaskVariableMap variables, NbGradleProject project, Lookup actionContext) {
+            return VariableValue.EMPTY_VALUE;
+        }
+    }),
+    JVM_LINE_ARGS("jvm-line-args", new ValueGetter<NbGradleProject>() {
         @Override
         public VariableValue getValue(TaskVariableMap variables, NbGradleProject project, Lookup actionContext) {
             return VariableValue.EMPTY_VALUE;

--- a/netbeans-gradle-plugin/src/main/resources/org/netbeans/gradle/project/resources/nb-init-script.gradle
+++ b/netbeans-gradle-plugin/src/main/resources/org/netbeans/gradle/project/resources/nb-init-script.gradle
@@ -24,32 +24,36 @@ void configureProject(def project) {
 
     boolean hasRun = runTask != null
     boolean hasDebug = debugTask != null
+    boolean hasAppPlugin = project.plugins.hasPlugin("application")
 
     if (tasks.findByName('classes') != null && project.hasProperty('sourceSets')) {
         def definedMainClass = project.hasProperty('mainClass') ? project.mainClass : ''
         if (definedMainClass == null) definedMainClass = '';
         definedMainClass = definedMainClass.toString()
 
-        definedMainClass = updateMainClass(project, definedMainClass)
+        definedMainClass = updateMainClass(project, definedMainClass, hasAppPlugin)
 
+        def jvmLineArgs = getJvmLineArgs(project)
         def cmdLineArgs = getCmdLineArgs(project)
-        def javaExecJvmArgs = getJavaExecJvmArgs(project)
-
-        project.logger.debug("[nb-init-script] javaExec minHeapSize=${javaExecJvmArgs.minHeapSize}")
-        project.logger.debug("[nb-init-script] javaExec maxHeapSize=${javaExecJvmArgs.maxHeapSize}")
-        project.logger.debug("[nb-init-script] javaExec systemProperties=${javaExecJvmArgs.systemProperties}")
-        project.logger.debug("[nb-init-script] javaExec jvmArgs=${javaExecJvmArgs.jvmArgs}")
-        project.logger.debug("[nb-init-script] javaExec cmdLineArgs=${cmdLineArgs}")
 
         def configJavaExec = { JavaExec task ->
             task.main = definedMainClass
             task.classpath = project.sourceSets.main.runtimeClasspath
             task.standardInput = System.in
             task.args = cmdLineArgs
-            task.minHeapSize = javaExecJvmArgs.minHeapSize
-            task.maxHeapSize = javaExecJvmArgs.maxHeapSize
-            task.systemProperties = javaExecJvmArgs.systemProperties
-            task.jvmArgs = javaExecJvmArgs.jvmArgs
+            task.jvmArgs = jvmLineArgs
+        }
+
+        def updateJavaExec = { JavaExec task ->
+            if (!cmdLineArgs.isEmpty()) {
+                task.args = cmdLineArgs
+            }
+            if (!jvmLineArgs.isEmpty()) {
+                task.minHeapSize = null
+                task.maxHeapSize = null
+                task.systemProperties = [:]
+                task.jvmArgs = jvmLineArgs
+            }
         }
 
         if (!hasRun) {
@@ -64,12 +68,8 @@ void configureProject(def project) {
                 }
             }
         }
-        else if (!cmdLineArgs.isEmpty() && (runTask instanceof JavaExec)) {
-            runTask.args = cmdLineArgs
-            runTask.minHeapSize = javaExecJvmArgs.minHeapSize
-            runTask.maxHeapSize = javaExecJvmArgs.maxHeapSize
-            runTask.systemProperties = javaExecJvmArgs.systemProperties
-            runTask.jvmArgs = javaExecJvmArgs.jvmArgs
+        else if (runTask instanceof JavaExec) {
+            updateJavaExec(runTask)
         }
 
         if (!hasDebug) {
@@ -85,12 +85,8 @@ void configureProject(def project) {
                 }
             }
         }
-        else if (!cmdLineArgs.isEmpty() && (debugTask instanceof JavaExec)) {
-            debugTask.args = getCmdLineArgs(project)
-            debugTask.minHeapSize = javaExecJvmArgs.minHeapSize
-            debugTask.maxHeapSize = javaExecJvmArgs.maxHeapSize
-            debugTask.systemProperties = javaExecJvmArgs.systemProperties
-            debugTask.jvmArgs = javaExecJvmArgs.jvmArgs
+        else if (debugTask instanceof JavaExec) {
+            updateJavaExec(debugTask)
         }
     }
     else {
@@ -112,7 +108,7 @@ void configureProject(def project) {
         }
     }
 
-    updateDebugTaskArgs(project)
+    updateDebugTaskArgs(project, hasAppPlugin)
 }
 
 void createReportingRunTask(def project, String taskName) {
@@ -124,8 +120,7 @@ void createReportingRunTask(def project, String taskName) {
     })
 }
 
-String updateMainClass(def project, String srcMainClass) {
-    boolean hasAppPlugin = project.plugins.hasPlugin("application")
+String updateMainClass(def project, String srcMainClass, boolean hasAppPlugin) {
     if ('' != srcMainClass) {
         if (hasAppPlugin) {
             project.mainClassName = srcMainClass
@@ -158,7 +153,7 @@ List<String> getJvmLineArgs(def project) {
     return splitProjectProperty(project, 'jvmLineArgs')
 }
 
-void updateDebugTaskArgs(def project) {
+void updateDebugTaskArgs(def project, boolean hasAppPlugin) {
     List debuggerAttachArgs = null;
     if (project.hasProperty('debuggerJpdaPort')) {
         def debuggerPort = project.debuggerJpdaPort
@@ -190,6 +185,9 @@ void updateDebugTaskArgs(def project) {
         }
     }
     if ((task instanceof JavaExec) || (task instanceof Test)) {
+        if ((task instanceof JavaExec) && hasAppPlugin) {
+            task.jvmArgs(task.jvmArgs)
+        }
         updateJvmArgs(task, debuggerAttachArgs)
     }
 }
@@ -227,35 +225,6 @@ void updateJvmArgs(def task, List additionalArgs) {
         additionalArgsSet.remove(arg?.toString())
     }
     task.jvmArgs(additionalArgsSet)
-}
-
-Map<String, String> getJavaExecJvmArgs(def project) {
-    def jvmLineArgsList = getJvmLineArgs(project)
-
-    def systemProperties = [:]
-    def minHeapSize = '128m'
-    def maxHeapSize = '128m'
-    def jvmArgs = []
-
-    for (def arg : jvmLineArgsList) {
-        if (arg.startsWith('-D')) {
-            def kv = arg.substring(2).split('=', 2)
-            systemProperties[kv[0]] = kv.length >= 2 ? kv[1] : true
-        }
-        else if (arg.startsWith('-Xms')) {
-            minHeapSize = arg.substring(4)
-        }
-        else if (arg.startsWith('-Xmx')) {
-            maxHeapSize = arg.substring(4)
-        }
-        else {
-            jvmArgs += arg
-        }
-    }
-    return ['minHeapSize': minHeapSize,
-            'maxHeapSize': maxHeapSize,
-            'systemProperties': systemProperties,
-            'jvmArgs': jvmArgs ]
 }
 
 List<String> splitArgs(String cmdLine) {

--- a/netbeans-gradle-plugin/src/main/resources/org/netbeans/gradle/project/resources/nb-init-script.gradle
+++ b/netbeans-gradle-plugin/src/main/resources/org/netbeans/gradle/project/resources/nb-init-script.gradle
@@ -48,11 +48,11 @@ void configureProject(def project) {
             if (!cmdLineArgs.isEmpty()) {
                 task.args = cmdLineArgs
             }
+            if (hasAppPlugin) {
+                task.jvmArgs(task.jvmArgs)
+            }
             if (!jvmLineArgs.isEmpty()) {
-                task.minHeapSize = null
-                task.maxHeapSize = null
-                task.systemProperties = [:]
-                task.jvmArgs = jvmLineArgs
+                task.jvmArgs(jvmLineArgs)
             }
         }
 
@@ -108,7 +108,7 @@ void configureProject(def project) {
         }
     }
 
-    updateDebugTaskArgs(project, hasAppPlugin)
+    updateDebugTaskArgs(project)
 }
 
 void createReportingRunTask(def project, String taskName) {
@@ -153,7 +153,7 @@ List<String> getJvmLineArgs(def project) {
     return splitProjectProperty(project, 'jvmLineArgs')
 }
 
-void updateDebugTaskArgs(def project, boolean hasAppPlugin) {
+void updateDebugTaskArgs(def project) {
     List debuggerAttachArgs = null;
     if (project.hasProperty('debuggerJpdaPort')) {
         def debuggerPort = project.debuggerJpdaPort
@@ -185,9 +185,6 @@ void updateDebugTaskArgs(def project, boolean hasAppPlugin) {
         }
     }
     if ((task instanceof JavaExec) || (task instanceof Test)) {
-        if ((task instanceof JavaExec) && hasAppPlugin) {
-            task.jvmArgs(task.jvmArgs)
-        }
         updateJvmArgs(task, debuggerAttachArgs)
     }
 }

--- a/netbeans-gradle-plugin/src/main/resources/org/netbeans/gradle/project/resources/nb-init-script.gradle
+++ b/netbeans-gradle-plugin/src/main/resources/org/netbeans/gradle/project/resources/nb-init-script.gradle
@@ -33,12 +33,23 @@ void configureProject(def project) {
         definedMainClass = updateMainClass(project, definedMainClass)
 
         def cmdLineArgs = getCmdLineArgs(project)
+        def javaExecJvmArgs = getJavaExecJvmArgs(project)
+
+        project.logger.debug("[nb-init-script] javaExec minHeapSize=${javaExecJvmArgs.minHeapSize}")
+        project.logger.debug("[nb-init-script] javaExec maxHeapSize=${javaExecJvmArgs.maxHeapSize}")
+        project.logger.debug("[nb-init-script] javaExec systemProperties=${javaExecJvmArgs.systemProperties}")
+        project.logger.debug("[nb-init-script] javaExec jvmArgs=${javaExecJvmArgs.jvmArgs}")
+        project.logger.debug("[nb-init-script] javaExec cmdLineArgs=${cmdLineArgs}")
 
         def configJavaExec = { JavaExec task ->
             task.main = definedMainClass
             task.classpath = project.sourceSets.main.runtimeClasspath
             task.standardInput = System.in
             task.args = cmdLineArgs
+            task.minHeapSize = javaExecJvmArgs.minHeapSize
+            task.maxHeapSize = javaExecJvmArgs.maxHeapSize
+            task.systemProperties = javaExecJvmArgs.systemProperties
+            task.jvmArgs = javaExecJvmArgs.jvmArgs
         }
 
         if (!hasRun) {
@@ -55,6 +66,10 @@ void configureProject(def project) {
         }
         else if (!cmdLineArgs.isEmpty() && (runTask instanceof JavaExec)) {
             runTask.args = cmdLineArgs
+            runTask.minHeapSize = javaExecJvmArgs.minHeapSize
+            runTask.maxHeapSize = javaExecJvmArgs.maxHeapSize
+            runTask.systemProperties = javaExecJvmArgs.systemProperties
+            runTask.jvmArgs = javaExecJvmArgs.jvmArgs
         }
 
         if (!hasDebug) {
@@ -72,6 +87,10 @@ void configureProject(def project) {
         }
         else if (!cmdLineArgs.isEmpty() && (debugTask instanceof JavaExec)) {
             debugTask.args = getCmdLineArgs(project)
+            debugTask.minHeapSize = javaExecJvmArgs.minHeapSize
+            debugTask.maxHeapSize = javaExecJvmArgs.maxHeapSize
+            debugTask.systemProperties = javaExecJvmArgs.systemProperties
+            debugTask.jvmArgs = javaExecJvmArgs.jvmArgs
         }
     }
     else {
@@ -120,15 +139,23 @@ String updateMainClass(def project, String srcMainClass) {
     return srcMainClass
 }
 
-List<String> getCmdLineArgs(def project) {
-    def cmdLineArgs = project.hasProperty('cmdLineArgs') ? project.cmdLineArgs : ''
-    cmdLineArgs = cmdLineArgs?.toString()?.trim()
-    if (cmdLineArgs == null || cmdLineArgs == '') {
+List<String> splitProjectProperty(def project, def propertyName) {
+    def value = project.hasProperty(propertyName) ? project[propertyName] : ''
+    value = value?.toString()?.trim()
+    if (value == null || value == '') {
         return []
     }
     else {
-        return splitArgs(cmdLineArgs)
+        return splitArgs(value)
     }
+}
+
+List<String> getCmdLineArgs(def project) {
+    return splitProjectProperty(project, 'cmdLineArgs')
+}
+
+List<String> getJvmLineArgs(def project) {
+    return splitProjectProperty(project, 'jvmLineArgs')
 }
 
 void updateDebugTaskArgs(def project) {
@@ -200,6 +227,35 @@ void updateJvmArgs(def task, List additionalArgs) {
         additionalArgsSet.remove(arg?.toString())
     }
     task.jvmArgs(additionalArgsSet)
+}
+
+Map<String, String> getJavaExecJvmArgs(def project) {
+    def jvmLineArgsList = getJvmLineArgs(project)
+
+    def systemProperties = [:]
+    def minHeapSize = '128m'
+    def maxHeapSize = '128m'
+    def jvmArgs = []
+
+    for (def arg : jvmLineArgsList) {
+        if (arg.startsWith('-D')) {
+            def kv = arg.substring(2).split('=', 2)
+            systemProperties[kv[0]] = kv.length >= 2 ? kv[1] : true
+        }
+        else if (arg.startsWith('-Xms')) {
+            minHeapSize = arg.substring(4)
+        }
+        else if (arg.startsWith('-Xmx')) {
+            maxHeapSize = arg.substring(4)
+        }
+        else {
+            jvmArgs += arg
+        }
+    }
+    return ['minHeapSize': minHeapSize,
+            'maxHeapSize': maxHeapSize,
+            'systemProperties': systemProperties,
+            'jvmArgs': jvmArgs ]
 }
 
 List<String> splitArgs(String cmdLine) {


### PR DESCRIPTION
Update default nb-init-script and run/debug task windows to support jvm args definition.

Allow users to configure various jvm related properties of JavaExec gradle task from a single project property.