### PR TITLE
RegexpFileLineConsumer implements OutputLinkFinder

### DIFF
--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/output/RegexpFileLineConsumer.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/output/RegexpFileLineConsumer.java
@@ -1,0 +1,64 @@
+package org.netbeans.gradle.project.output;
+
+import java.io.File;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class RegexpFileLineConsumer implements OutputLinkFinder {
+    private static final Logger LOGGER = Logger.getLogger(RegexpFileLineConsumer.class.getName());
+
+    private static final Pattern FILE_LINE_PATTERN = Pattern.compile(
+            "\\s*((.*[/\\\\]+.+):(\\d+)):\\s+(?:error|warning):\\s[^\\s]+.*"
+    );
+
+    @Override
+    public OutputLinkDef tryFindLink(String line) {
+
+        Matcher matcher = FILE_LINE_PATTERN.matcher(line);
+        if (!matcher.find()) {
+            return null;
+        }
+        if (matcher.groupCount() != 3) {
+            return null;
+        }
+
+        int lineNumber;
+        try {
+            lineNumber = Integer.parseInt(matcher.group(3));
+        }
+        catch (NumberFormatException ex) {
+            // should not be possible
+            return null;
+        }
+
+        String path = matcher.group(2).trim();
+        File file;
+        try {
+            file = new File(path);
+            if (!file.isFile()) {
+                return null;
+            }
+        }
+        catch (Exception ex) {
+            LOGGER.log(Level.WARNING, "Path displayed in the output is not readable: {0}", path);
+            return null;
+        }
+
+        return createLink(line, file, path, lineNumber, matcher.group(1).length());
+    }
+
+    private static OutputLinkDef createLink(String line, File file, String path, int lineNumber, int linkLength) {
+
+        Runnable listener = OpenEditorOutputListener.tryCreateListener(file, lineNumber);
+        if (listener == null) {
+            LOGGER.log(Level.WARNING, "File displayed in the output disappeared: {0}", file);
+            return null;
+        }
+
+        int startIndex = line.indexOf(path);
+        return new OutputLinkDef(startIndex, startIndex + linkLength, listener);
+    }
+
+}

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/tasks/AsyncGradleTask.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/tasks/AsyncGradleTask.java
@@ -70,6 +70,7 @@ import org.netbeans.gradle.project.output.OutputLinkFinder;
 import org.netbeans.gradle.project.output.OutputLinkPrinter;
 import org.netbeans.gradle.project.output.OutputUrlConsumer;
 import org.netbeans.gradle.project.output.ReaderInputStream;
+import org.netbeans.gradle.project.output.RegexpFileLineConsumer;
 import org.netbeans.gradle.project.output.ReplaceLineFeedReader;
 import org.netbeans.gradle.project.output.SmartOutputHandler;
 import org.netbeans.gradle.project.output.StackTraceConsumer;
@@ -302,7 +303,8 @@ public final class AsyncGradleTask implements Runnable {
                 new StackTraceConsumer(project),
                 new OutputUrlConsumer(),
                 projectDirLinks(project),
-                new FileLineConsumer()));
+                new FileLineConsumer(),
+                new RegexpFileLineConsumer()));
 
         InputOutputWrapper io = tab.getIo();
         Writer forwardedStdOut = new LineOutputWriter(new SmartOutputHandler(


### PR DESCRIPTION
Added `RegexpFileLineConsumer implements OutputLinkFinder` to recognize lines of the form `path:line: error/warning: message`.

Added only to stderr consumer since that's where this kind of message appears.

Tested on macOS, should work on Windows.