### PR TITLE
Changed source file resolution to accommodate javafx 11 libraries.

### DIFF
--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/GradleCacheByBinaryLookup.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/GradleCacheByBinaryLookup.java
@@ -72,7 +72,7 @@ public final class GradleCacheByBinaryLookup {
             if (artifactRoot == null) {
                 return null;
             }
-            String sourceFileName = artifactRoot.getNameExt() + "-" + binDir.getNameExt() + GradleFileUtils.SOURCES_CLASSIFIER;
+            String sourceFileName = artifactRoot.getNameExt() + "-" + binDir.getNameExt() + GradleFileUtils.SOURCES_SUFFIX;
             return new NewFormatCacheResult(binDir, sourceFileName);
         }
 

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/GradleCacheByBinaryLookup.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/GradleCacheByBinaryLookup.java
@@ -59,18 +59,24 @@ public final class GradleCacheByBinaryLookup {
             return null;
         }
 
-        String sourceFileName = binaryToSearchedEntry.apply(binaryRootObj);
-
         if (GradleFileUtils.isKnownBinaryDirName(binDir.getNameExt())) {
             final FileObject artifactRoot = binDir.getParent();
             if (artifactRoot == null) {
                 return null;
             }
-
+            String sourceFileName = binaryToSearchedEntry.apply(binaryRootObj);
             return new OldFormatCacheResult(artifactRoot, searchedPackaging, sourceFileName);
         }
+        else {
+            final FileObject artifactRoot = binDir.getParent();
+            if (artifactRoot == null) {
+                return null;
+            }
+            String sourceFileName = artifactRoot.getNameExt() + "-" + binDir.getNameExt() + GradleFileUtils.SOURCES_CLASSIFIER;
+            return new NewFormatCacheResult(binDir, sourceFileName);
+        }
 
-        return new NewFormatCacheResult(binDir, sourceFileName);
+
     }
 
     private static final class EventSource

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/GradleCacheByBinaryLookup.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/GradleCacheByBinaryLookup.java
@@ -13,6 +13,7 @@ import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 
 public final class GradleCacheByBinaryLookup {
+
     private static final FileObject[] NO_ROOTS = new FileObject[0];
     private static final LazyChangeSupport CHANGES = LazyChangeSupport.createSwing(new EventSource());
 
@@ -59,28 +60,21 @@ public final class GradleCacheByBinaryLookup {
             return null;
         }
 
-        if (GradleFileUtils.isKnownBinaryDirName(binDir.getNameExt())) {
-            final FileObject artifactRoot = binDir.getParent();
-            if (artifactRoot == null) {
-                return null;
-            }
-            String sourceFileName = binaryToSearchedEntry.apply(binaryRootObj);
-            return new OldFormatCacheResult(artifactRoot, searchedPackaging, sourceFileName);
+        final FileObject artifactRoot = binDir.getParent();
+        if (artifactRoot == null) {
+            return null;
         }
-        else {
-            final FileObject artifactRoot = binDir.getParent();
-            if (artifactRoot == null) {
-                return null;
-            }
-            String sourceFileName = artifactRoot.getNameExt() + "-" + binDir.getNameExt() + GradleFileUtils.SOURCES_SUFFIX;
+
+        String sourceFileName = binaryToSearchedEntry.apply(binaryRootObj);
+        if (GradleFileUtils.isKnownBinaryDirName(binDir.getNameExt())) {
+            return new OldFormatCacheResult(artifactRoot, searchedPackaging, sourceFileName);
+        } else {
             return new NewFormatCacheResult(binDir, sourceFileName);
         }
-
-
     }
 
     private static final class EventSource
-    implements
+            implements
             SourceForBinaryQueryImplementation2.Result,
             LazyChangeSupport.Source {
 
@@ -114,6 +108,7 @@ public final class GradleCacheByBinaryLookup {
     }
 
     private static class NewFormatCacheResult implements SourceForBinaryQueryImplementation2.Result {
+
         private final FileObject artifactRoot;
         private final String sourceFileName;
 
@@ -150,6 +145,7 @@ public final class GradleCacheByBinaryLookup {
     }
 
     private static class OldFormatCacheResult implements SourceForBinaryQueryImplementation2.Result {
+
         private final FileObject artifactRoot;
         private final String searchedPackaging;
         private final String searchedFileName;
@@ -167,7 +163,7 @@ public final class GradleCacheByBinaryLookup {
 
         @Override
         public FileObject[] getRoots() {
-                // The cache directory of Gradle looks like this:
+            // The cache directory of Gradle looks like this:
             //
             // ...... \\source\\HASH_OF_SOURCE\\binary-sources.jar
             // ...... \\packaging type\\HASH_OF_BINARY\\binary.jar

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/util/GradleFileUtils.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/util/GradleFileUtils.java
@@ -98,15 +98,37 @@ public final class GradleFileUtils {
     }
 
     public static String binaryToSourceName(FileObject binaryPath) {
-        String binFileName = binaryPath.getName();
         String binFileExt = binaryPath.getExt();
-        return binFileName + SOURCES_CLASSIFIER + "." + binFileExt;
+        return binaryToBaseName(binaryPath) + SOURCES_CLASSIFIER + "." + binFileExt;
     }
 
     public static String binaryToJavadocName(FileObject binaryPath) {
-        String binFileName = binaryPath.getName();
         String binFileExt = binaryPath.getExt();
-        return binFileName + JAVADOC_CLASSIFIER + "." + binFileExt;
+        return binaryToBaseName(binaryPath) + JAVADOC_CLASSIFIER + "." + binFileExt;
+    }
+    
+    public static String binaryToBaseName(FileObject binaryPath) {
+        FileObject hashDir = binaryPath.getParent();
+        if (hashDir == null) {
+            return binaryPath.getName();
+        }
+
+        FileObject binDir = hashDir.getParent();
+        if (binDir == null) {
+            return binaryPath.getName();
+        }
+
+        if (GradleFileUtils.isKnownBinaryDirName(binDir.getNameExt())) {
+            return binaryPath.getName();
+        }
+        else {
+            final FileObject versionDir = binDir;
+            final FileObject artifactRoot = binDir.getParent();
+            if (artifactRoot == null) {
+                return binaryPath.getName();
+            }
+            return artifactRoot.getNameExt() + "-" + versionDir.getNameExt();
+        }
     }
 
     public static String sourceToBinaryName(FileObject sourcePath) {

--- a/netbeans-gradle-plugin/src/test/java/org/netbeans/gradle/project/query/GradleCacheJavadocForBinaryQueryTest.java
+++ b/netbeans-gradle-plugin/src/test/java/org/netbeans/gradle/project/query/GradleCacheJavadocForBinaryQueryTest.java
@@ -1,0 +1,264 @@
+package org.netbeans.gradle.project.query;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.netbeans.api.java.queries.SourceForBinaryQuery;
+import org.netbeans.gradle.model.util.BasicFileUtils;
+import org.netbeans.gradle.project.util.SafeTmpFolder;
+import org.netbeans.gradle.project.util.TestBinaryUtils;
+import org.netbeans.spi.java.queries.SourceForBinaryQueryImplementation2;
+import org.openide.util.Utilities;
+
+import static org.junit.Assert.*;
+import org.netbeans.api.java.queries.JavadocForBinaryQuery;
+import static org.netbeans.gradle.project.query.TestSourceQueryUtils.*;
+import org.netbeans.spi.java.queries.JavadocForBinaryQueryImplementation;
+
+public class GradleCacheJavadocForBinaryQueryTest {
+
+    @ClassRule
+    public static final SafeTmpFolder TMP_DIR_ROOT = new SafeTmpFolder();
+
+    private static SourceForBinaryQueryImplementation2 createWithRoot(final File gradleHomeRoot) {
+        return new GradleCacheSourceForBinaryQuery(() -> gradleHomeRoot);
+    }
+
+    private static JavadocForBinaryQueryImplementation createJavadocQueryWithRoot(final File gradleHomeRoot) {
+        return new GradleCacheJavadocForBinaryQuery(() -> gradleHomeRoot);
+    }
+
+    private void verifySource(File gradleHome, URL binaryUrl, File srcFile) {
+        SourceForBinaryQueryImplementation2 query = createWithRoot(gradleHome);
+
+        SourceForBinaryQuery.Result result1 = query.findSourceRoots(binaryUrl);
+        assertNotNull("result1", result1);
+        expectSameArchive("sourcesPath", srcFile, expectedSingleFile(result1));
+
+        SourceForBinaryQueryImplementation2.Result result2 = query.findSourceRoots2(binaryUrl);
+        assertNotNull("result2", result2);
+        expectSameArchive("sourcesPath", srcFile, expectedSingleFile(result2));
+        assertFalse("preferSources", result2.preferSources());
+    }
+
+    private void verifyJavadoc(File gradleHome, URL binaryUrl, File javadocFile, boolean hasSources) {
+        JavadocForBinaryQueryImplementation query = createJavadocQueryWithRoot(gradleHome);
+
+        JavadocForBinaryQuery.Result result = query.findJavadoc(binaryUrl);
+        if (hasSources) {
+            assertNull("result", result);
+        } else {
+            assertNotNull("result", result);
+            expectSameArchive("javadocPath", javadocFile, expectedSingleFile(result));
+        }
+    }
+
+    private void verifyNotDownloadedSource(File gradleHome, URL binaryUrl) {
+        SourceForBinaryQueryImplementation2 query = createWithRoot(gradleHome);
+
+        SourceForBinaryQuery.Result result1 = query.findSourceRoots(binaryUrl);
+        assertNotNull("result1", result1);
+        assertEquals("sourcesPath", 0, result1.getRoots().length);
+
+        SourceForBinaryQueryImplementation2.Result result2 = query.findSourceRoots2(binaryUrl);
+        assertNotNull("result2", result2);
+        assertEquals("sourcesPath", 0, result2.getRoots().length);
+        assertFalse("preferSources", result2.preferSources());
+    }
+
+    @Test
+    public void testOldCacheFormat() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
+        File jarDir = BasicFileUtils.getSubPath(artifactRoot, "jar", "43253");
+        File jar = BasicFileUtils.getSubPath(jarDir, "myproj.jar");
+
+        jarDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File srcDir = BasicFileUtils.getSubPath(artifactRoot, "source", "643632");
+        File srcFile = BasicFileUtils.getSubPath(srcDir, "myproj-sources.jar");
+
+        srcDir.mkdirs();
+        TestBinaryUtils.createTestJar(srcFile);
+
+        File javadocDir = BasicFileUtils.getSubPath(artifactRoot, "javadoc", "676767");
+        File javadocFile = BasicFileUtils.getSubPath(javadocDir, "myproj-javadoc.jar");
+
+        javadocDir.mkdirs();
+        TestBinaryUtils.createTestJar(javadocFile);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifySource(gradleHome, binaryUrl, srcFile);
+        verifyJavadoc(gradleHome, binaryUrl, javadocFile, true);
+    }
+
+    @Test
+    public void testOldCacheFormatMissingSource() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
+        File jarDir = BasicFileUtils.getSubPath(artifactRoot, "jar", "43253");
+        File jar = BasicFileUtils.getSubPath(jarDir, "myproj.jar");
+
+        jarDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File javadocDir = BasicFileUtils.getSubPath(artifactRoot, "javadoc", "676767");
+        File javadocFile = BasicFileUtils.getSubPath(javadocDir, "myproj-javadoc.jar");
+
+        javadocDir.mkdirs();
+        TestBinaryUtils.createTestJar(javadocFile);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifyNotDownloadedSource(gradleHome, binaryUrl);
+        verifyJavadoc(gradleHome, binaryUrl, javadocFile, false);
+    }
+
+    @Test
+    public void testNewCacheFormat() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2");
+        File jarDir = BasicFileUtils.getSubPath(versionDir, "57436");
+        File jar = BasicFileUtils.getSubPath(jarDir, "myproj-11.2.jar");
+
+        jarDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File srcDir = BasicFileUtils.getSubPath(versionDir, "25754");
+        File srcFile = BasicFileUtils.getSubPath(srcDir, "myproj-11.2-sources.jar");
+
+        srcDir.mkdirs();
+        TestBinaryUtils.createTestJar(srcFile);
+
+        File javadocDir = BasicFileUtils.getSubPath(versionDir, "57657");
+        File javadocFile = BasicFileUtils.getSubPath(javadocDir, "myproj-11.2-javadoc.jar");
+
+        javadocDir.mkdirs();
+        TestBinaryUtils.createTestJar(javadocFile);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifySource(gradleHome, binaryUrl, srcFile);
+        verifyJavadoc(gradleHome, binaryUrl, javadocFile, true);
+    }
+
+    @Test
+    public void testNewCacheFormatMissingSource() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2");
+        File jarDir = BasicFileUtils.getSubPath(versionDir, "57436");
+        File jar = BasicFileUtils.getSubPath(jarDir, "myproj-11.2.jar");
+
+        jarDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File javadocDir = BasicFileUtils.getSubPath(versionDir, "57657");
+        File javadocFile = BasicFileUtils.getSubPath(javadocDir, "myproj-11.2-javadoc.jar");
+
+        javadocDir.mkdirs();
+        TestBinaryUtils.createTestJar(javadocFile);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifyNotDownloadedSource(gradleHome, binaryUrl);
+        verifyJavadoc(gradleHome, binaryUrl, javadocFile, false);
+    }
+
+    @Test
+    public void testNewCacheFormatMultipleBinaries() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org.openjfx", "javafx-base");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2");
+        File jarDir1 = BasicFileUtils.getSubPath(versionDir, "57436");
+        File binary1 = BasicFileUtils.getSubPath(jarDir1, "javafx-base-11.2-win.jar");
+
+        File jarDir2 = BasicFileUtils.getSubPath(versionDir, "63457");
+        File binary2 = BasicFileUtils.getSubPath(jarDir2, "javafx-base-11.2.jar");
+
+        jarDir1.mkdirs();
+        TestBinaryUtils.createTestJar(binary1);
+
+        jarDir2.mkdirs();
+        TestBinaryUtils.createTestJar(binary2);
+
+        File srcDir = BasicFileUtils.getSubPath(versionDir, "25754");
+        File srcFile = BasicFileUtils.getSubPath(srcDir, "javafx-base-11.2-sources.jar");
+
+        srcDir.mkdirs();
+        TestBinaryUtils.createTestJar(srcFile);
+
+        File javadocDir = BasicFileUtils.getSubPath(versionDir, "57657");
+        File javadocFile = BasicFileUtils.getSubPath(javadocDir, "javafx-base-11.2-javadoc.jar");
+
+        javadocDir.mkdirs();
+        TestBinaryUtils.createTestJar(javadocFile);
+
+        URL binaryUrl1 = Utilities.toURI(binary1).toURL();
+        verifySource(gradleHome, binaryUrl1, srcFile);
+        verifyJavadoc(gradleHome, binaryUrl1, javadocFile, true);
+
+        URL binaryUrl2 = Utilities.toURI(binary2).toURL();
+        verifySource(gradleHome, binaryUrl2, srcFile);
+        verifyJavadoc(gradleHome, binaryUrl2, javadocFile, true);
+    }
+
+    @Test
+    public void testNewCacheFormatMultipleBinariesMissingSource() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org.openjfx", "javafx-base");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11");
+        File jarDir1 = BasicFileUtils.getSubPath(versionDir, "57436");
+        File binary1 = BasicFileUtils.getSubPath(jarDir1, "javafx-base-11-win.jar");
+
+        File jarDir2 = BasicFileUtils.getSubPath(versionDir, "63457");
+        File binary2 = BasicFileUtils.getSubPath(jarDir2, "javafx-base-11.jar");
+
+        jarDir1.mkdirs();
+        TestBinaryUtils.createTestJar(binary1);
+
+        jarDir2.mkdirs();
+        TestBinaryUtils.createTestJar(binary2);
+
+        File javadocDir = BasicFileUtils.getSubPath(versionDir, "57657");
+        File javadocFile = BasicFileUtils.getSubPath(javadocDir, "javafx-base-11-javadoc.jar");
+
+        javadocDir.mkdirs();
+        TestBinaryUtils.createTestJar(javadocFile);
+
+        URL binaryUrl1 = Utilities.toURI(binary1).toURL();
+        verifyJavadoc(gradleHome, binaryUrl1, javadocFile, false);
+
+        URL binaryUrl2 = Utilities.toURI(binary2).toURL();
+        verifyJavadoc(gradleHome, binaryUrl2, javadocFile, false);
+    }
+
+    @Test
+    public void testJavadoccNotInCache() throws IOException {
+        File root = TMP_DIR_ROOT.newFolder();
+
+        File gradleHome = new File(root, ".gradle");
+        gradleHome.mkdirs();
+
+        File binaryHome = new File(root, "otherdir");
+
+        File artifactRoot = BasicFileUtils.getSubPath(binaryHome, "org", "myproj");
+        File jarDir = BasicFileUtils.getSubPath(artifactRoot, "57436");
+        File jar = BasicFileUtils.getSubPath(jarDir, "myproj.jar");
+
+        jarDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        
+        JavadocForBinaryQueryImplementation query = createJavadocQueryWithRoot(gradleHome);
+        assertNull("result", query.findJavadoc(binaryUrl));
+    }
+}

--- a/netbeans-gradle-plugin/src/test/java/org/netbeans/gradle/project/query/GradleCacheSourceForBinaryQueryTest.java
+++ b/netbeans-gradle-plugin/src/test/java/org/netbeans/gradle/project/query/GradleCacheSourceForBinaryQueryTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.*;
 import static org.netbeans.gradle.project.query.TestSourceQueryUtils.*;
 
 public class GradleCacheSourceForBinaryQueryTest {
+
     @ClassRule
     public static final SafeTmpFolder TMP_DIR_ROOT = new SafeTmpFolder();
 
@@ -90,14 +91,15 @@ public class GradleCacheSourceForBinaryQueryTest {
         File gradleHome = TMP_DIR_ROOT.newFolder();
 
         File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
-        File jarDir = BasicFileUtils.getSubPath(artifactRoot, "57436");
-        File jar = BasicFileUtils.getSubPath(jarDir, "myproj.jar");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2");
+        File jarDir = BasicFileUtils.getSubPath(versionDir, "57436");
+        File jar = BasicFileUtils.getSubPath(jarDir, "myproj-11.2.jar");
 
         jarDir.mkdirs();
         TestBinaryUtils.createTestJar(jar);
 
-        File srcDir = BasicFileUtils.getSubPath(artifactRoot, "25754");
-        File srcFile = BasicFileUtils.getSubPath(srcDir, "myproj-sources.jar");
+        File srcDir = BasicFileUtils.getSubPath(versionDir, "25754");
+        File srcFile = BasicFileUtils.getSubPath(srcDir, "myproj-11.2-sources.jar");
 
         srcDir.mkdirs();
         TestBinaryUtils.createTestJar(srcFile);
@@ -119,6 +121,37 @@ public class GradleCacheSourceForBinaryQueryTest {
 
         URL binaryUrl = Utilities.toURI(jar).toURL();
         verifyNotDownloadedSource(gradleHome, binaryUrl);
+    }
+
+    @Test
+    public void testNewCacheFormatMultipleBinaries() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org.openjfx", "javafx-base");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11");
+        File jarDir1 = BasicFileUtils.getSubPath(versionDir, "57436");
+        File binary1 = BasicFileUtils.getSubPath(jarDir1, "javafx-base-11-win.jar");
+
+        File jarDir2 = BasicFileUtils.getSubPath(versionDir, "63457");
+        File binary2 = BasicFileUtils.getSubPath(jarDir2, "javafx-base-11.jar");
+
+        jarDir1.mkdirs();
+        TestBinaryUtils.createTestJar(binary1);
+
+        jarDir2.mkdirs();
+        TestBinaryUtils.createTestJar(binary2);
+
+        File srcDir = BasicFileUtils.getSubPath(versionDir, "25754");
+        File srcFile = BasicFileUtils.getSubPath(srcDir, "javafx-base-11-sources.jar");
+
+        srcDir.mkdirs();
+        TestBinaryUtils.createTestJar(srcFile);
+
+        URL binaryUrl1 = Utilities.toURI(binary1).toURL();
+        verifySource(gradleHome, binaryUrl1, srcFile);
+        
+        URL binaryUrl2 = Utilities.toURI(binary2).toURL();
+        verifySource(gradleHome, binaryUrl2, srcFile);
     }
 
     @Test

--- a/netbeans-gradle-plugin/src/test/java/org/netbeans/gradle/project/query/TestSourceQueryUtils.java
+++ b/netbeans-gradle-plugin/src/test/java/org/netbeans/gradle/project/query/TestSourceQueryUtils.java
@@ -10,8 +10,10 @@ import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 
 import static org.junit.Assert.*;
+import org.netbeans.api.java.queries.JavadocForBinaryQuery;
 
 public final class TestSourceQueryUtils {
+
     public static void expectSameArchive(String name, File expected, FileObject actual) {
         URI expectedUri;
         try {
@@ -21,10 +23,34 @@ public final class TestSourceQueryUtils {
         }
 
         URI actualUri = actual.toURI();
+        expectSameArchive(name, expectedUri, actualUri);
+    }
+
+    public static void expectSameArchive(String name, File expected, File actual) {
+        URI expectedUri;
+        try {
+            expectedUri = FileUtil.urlForArchiveOrDir(expected).toURI();
+        } catch (URISyntaxException ex) {
+            throw new RuntimeException(ex);
+        }
+        URI actualUri;
+        try {
+            actualUri = FileUtil.urlForArchiveOrDir(actual).toURI();
+        } catch (URISyntaxException ex) {
+            throw new RuntimeException(ex);
+        }
+        expectSameArchive(name, expectedUri, actualUri);
+    }
+
+    public static void expectSameArchive(String name, URI expectedUri, URI actualUri) {
         assertEquals(name, expectedUri, actualUri);
     }
 
     public static File expectedSingleFile(BinaryForSourceQuery.Result result) {
+        return expectedSingleFile(result.getRoots());
+    }
+
+    public static File expectedSingleFile(JavadocForBinaryQuery.Result result) {
         return expectedSingleFile(result.getRoots());
     }
 


### PR DESCRIPTION
The sources associated with openjfx (https://openjfx.io/openjfx-docs/#gradle) libraries aren't linked properly because there are multiple binaries associated with a single set of source files as seen here: http://central.maven.org/maven2/org/openjfx/javafx-controls/11/

I have made some changes. If they are not appropriate, I'll be happy to make any changes you require.