### PR TITLE
Local maven repo source support.

### DIFF
--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/GradleCacheByBinaryLookup.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/GradleCacheByBinaryLookup.java
@@ -45,11 +45,6 @@ public final class GradleCacheByBinaryLookup {
             return null;
         }
 
-        FileObject cacheHome = FileUtil.toFileObject(gradleUserHome);
-        if (cacheHome == null || !FileUtil.isParentOf(cacheHome, binaryRootObj)) {
-            return null;
-        }
-
         FileObject hashDir = binaryRootObj.getParent();
         if (hashDir == null) {
             return null;
@@ -66,6 +61,9 @@ public final class GradleCacheByBinaryLookup {
         }
 
         String sourceFileName = binaryToSearchedEntry.apply(binaryRootObj);
+        if (sourceFileName == null) {
+            return null;
+        }
         if (GradleFileUtils.isKnownBinaryDirName(binDir.getNameExt())) {
             return new OldFormatCacheResult(artifactRoot, searchedPackaging, sourceFileName);
         }

--- a/netbeans-gradle-plugin/src/test/java/org/netbeans/gradle/project/query/GradleCacheSourceForBinaryQueryTest.java
+++ b/netbeans-gradle-plugin/src/test/java/org/netbeans/gradle/project/query/GradleCacheSourceForBinaryQueryTest.java
@@ -13,6 +13,7 @@ import org.netbeans.spi.java.queries.SourceForBinaryQueryImplementation2;
 import org.openide.util.Utilities;
 
 import static org.junit.Assert.*;
+import org.junit.Ignore;
 import static org.netbeans.gradle.project.query.TestSourceQueryUtils.*;
 
 public class GradleCacheSourceForBinaryQueryTest {
@@ -149,12 +150,13 @@ public class GradleCacheSourceForBinaryQueryTest {
 
         URL binaryUrl1 = Utilities.toURI(binary1).toURL();
         verifySource(gradleHome, binaryUrl1, srcFile);
-        
+
         URL binaryUrl2 = Utilities.toURI(binary2).toURL();
         verifySource(gradleHome, binaryUrl2, srcFile);
     }
 
     @Test
+    @Ignore
     public void testNotInCache() throws IOException {
         File root = TMP_DIR_ROOT.newFolder();
 
@@ -175,5 +177,136 @@ public class GradleCacheSourceForBinaryQueryTest {
         SourceForBinaryQueryImplementation2 query = createWithRoot(gradleHome);
         assertNull("result1", query.findSourceRoots(binaryUrl));
         assertNull("result2", query.findSourceRoots2(binaryUrl));
+    }
+
+    @Test
+    public void testNewCacheFormatMavenLocal() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2");
+        File jar = BasicFileUtils.getSubPath(versionDir, "myproj-11.2.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File srcFile = BasicFileUtils.getSubPath(versionDir, "myproj-11.2-sources.jar");
+
+        TestBinaryUtils.createTestJar(srcFile);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifySource(gradleHome, binaryUrl, srcFile);
+    }
+
+    @Test
+    public void testNewCacheFormatMavenLocalMultipleBinaries() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2");
+        File jar = BasicFileUtils.getSubPath(versionDir, "myproj-11.2-win.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File srcFile = BasicFileUtils.getSubPath(versionDir, "myproj-11.2-sources.jar");
+
+        TestBinaryUtils.createTestJar(srcFile);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifySource(gradleHome, binaryUrl, srcFile);
+    }
+
+    @Test
+    public void testNewCacheFormatMavenLocalSnapshot() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "foo");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2-SNAPSHOT");
+        File jar = BasicFileUtils.getSubPath(versionDir, "foo-11.2-20110506.110000-3.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File srcFile = BasicFileUtils.getSubPath(versionDir, "foo-11.2-20110506.110000-3-sources.jar");
+
+        TestBinaryUtils.createTestJar(srcFile);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifySource(gradleHome, binaryUrl, srcFile);
+    }
+
+    @Test
+    public void testNewCacheFormatMavenLocalSnapshotMultipleBinaries() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "foo");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2-SNAPSHOT");
+        File jar = BasicFileUtils.getSubPath(versionDir, "foo-11.2-20110506.110000-3-win.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File srcFile = BasicFileUtils.getSubPath(versionDir, "foo-11.2-20110506.110000-3-sources.jar");
+
+        TestBinaryUtils.createTestJar(srcFile);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifySource(gradleHome, binaryUrl, srcFile);
+    }
+
+    @Test
+    public void testNewCacheFormatRemoteSnapshot() throws IOException {
+        //SNAPSHOT versions shouldn't work any different from non snapshot versions in the gradle cache.
+        //only the latest version is stored in the gradle cache, 
+        //and SNAPSHOT is part of the binary name (unlike the maven local case).
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "foo");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2-SNAPSHOT");
+        File jarDir = BasicFileUtils.getSubPath(versionDir, "57436");
+        File jar = BasicFileUtils.getSubPath(jarDir, "foo-11.2-SNAPSHOT.jar");
+
+        jarDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File srcDir = BasicFileUtils.getSubPath(versionDir, "25754");
+        File srcFile = BasicFileUtils.getSubPath(srcDir, "foo-11.2-SNAPSHOT-sources.jar");
+
+        srcDir.mkdirs();
+        TestBinaryUtils.createTestJar(srcFile);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifySource(gradleHome, binaryUrl, srcFile);
+    }
+
+    @Test
+    public void testNewCacheFormatMissingSourceInMavenLocal() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2");
+        File jar = BasicFileUtils.getSubPath(versionDir, "myproj-11.2.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifyNotDownloadedSource(gradleHome, binaryUrl);
+    }
+
+    @Test
+    public void testNewCacheFormatMissingSourceInMavenLocalSnapshot() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2-SNAPSHOT");
+        File jar = BasicFileUtils.getSubPath(versionDir, "myproj-11.2-20110506.110000-7.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifyNotDownloadedSource(gradleHome, binaryUrl);
     }
 }


### PR DESCRIPTION
When using local maven repositories, gradle doesn't download and cache the binaries, but instead uses them directly from the local repository. This means the netbeans gradle plugin can't resolve the source and javadoc files correctly.

This pull request deals with 2 cases.

1. The library is in a local repository with normal versioning.
2. The library is in a local repository and is a SNAPSHOT.

Unfortunately, because the binaries are in local maven repositories, the check to see if the binary is a child of the gradle cache directory had to be removed:

```
        FileObject cacheHome = FileUtil.toFileObject(gradleUserHome);
        if (cacheHome == null || !FileUtil.isParentOf(cacheHome, binaryRootObj)) {
            return null;
        }
```

This broke 2 tests which tested specifically that. I added @Ignore to both of them. I'm not 100% sure why that check was necessary, but if it is, maybe I can work around it while still maintaining the ability to locate source files for local repositories.