### PR TITLE
Added source support for custom local maven repos

### DIFF
--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/MavenLocalBinaryForSourceQuery.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/MavenLocalBinaryForSourceQuery.java
@@ -5,8 +5,6 @@ import java.net.URL;
 import javax.swing.event.ChangeListener;
 import org.netbeans.api.java.queries.BinaryForSourceQuery;
 import org.netbeans.api.java.queries.BinaryForSourceQuery.Result;
-import org.netbeans.gradle.project.util.GradleFileUtils;
-import org.netbeans.gradle.project.util.LazyChangeSupport;
 import org.netbeans.gradle.project.util.MavenFileUtils;
 import org.netbeans.gradle.project.util.NbFileUtils;
 import org.netbeans.spi.java.queries.BinaryForSourceQueryImplementation;

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/MavenLocalBinaryForSourceQuery.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/MavenLocalBinaryForSourceQuery.java
@@ -1,0 +1,68 @@
+package org.netbeans.gradle.project.query;
+
+import java.io.File;
+import java.net.URL;
+import javax.swing.event.ChangeListener;
+import org.netbeans.api.java.queries.BinaryForSourceQuery;
+import org.netbeans.api.java.queries.BinaryForSourceQuery.Result;
+import org.netbeans.gradle.project.util.GradleFileUtils;
+import org.netbeans.gradle.project.util.LazyChangeSupport;
+import org.netbeans.gradle.project.util.MavenFileUtils;
+import org.netbeans.gradle.project.util.NbFileUtils;
+import org.netbeans.spi.java.queries.BinaryForSourceQueryImplementation;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.lookup.ServiceProvider;
+import org.openide.util.lookup.ServiceProviders;
+
+@ServiceProviders({
+    @ServiceProvider(service = BinaryForSourceQueryImplementation.class)})
+public final class MavenLocalBinaryForSourceQuery extends AbstractBinaryForSourceQuery {
+
+    public MavenLocalBinaryForSourceQuery() {
+    }
+
+    @Override
+    protected Result tryFindBinaryRoots(File sourceRoot) {
+        final FileObject sourceRootObj = FileUtil.toFileObject(sourceRoot);
+        if (sourceRootObj == null) {
+            return null;
+        }
+
+        final String binFileName = MavenFileUtils.sourceToBinaryName(sourceRootObj);
+        if (binFileName == null) {
+            return null;
+        }
+        if (!MavenFileUtils.isSourceFile(sourceRootObj)) {
+            return null;
+        }
+        
+        File sourceRootParent = sourceRoot.getParentFile();
+        File binaryFile = new File(sourceRootParent, binFileName);
+        FileObject binaryFileObj = FileUtil.toFileObject(binaryFile);
+        if (binaryFileObj == null) {
+            return null;
+        }
+
+        FileObject asArchive = NbFileUtils.asArchiveOrDir(binaryFileObj);
+        if (asArchive == null) {
+            return null;
+        }
+        
+        return new BinaryForSourceQuery.Result() {
+            @Override
+            public URL[] getRoots() {
+                return new URL[]{asArchive.toURL()};
+            }
+
+            @Override
+            public void addChangeListener(ChangeListener l) {
+            }
+
+            @Override
+            public void removeChangeListener(ChangeListener l) {
+            }
+        };
+    }
+
+}

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/MavenLocalJavadocForBinaryQuery.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/MavenLocalJavadocForBinaryQuery.java
@@ -1,0 +1,78 @@
+package org.netbeans.gradle.project.query;
+
+import java.io.File;
+import java.net.URL;
+import javax.swing.event.ChangeListener;
+import org.netbeans.api.java.queries.JavadocForBinaryQuery;
+import org.netbeans.gradle.project.util.MavenFileUtils;
+import org.netbeans.gradle.project.util.NbFileUtils;
+import org.netbeans.spi.java.queries.JavadocForBinaryQueryImplementation;
+import org.netbeans.spi.java.queries.SourceForBinaryQueryImplementation2;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.lookup.ServiceProvider;
+import org.openide.util.lookup.ServiceProviders;
+
+@ServiceProviders({
+    @ServiceProvider(service = JavadocForBinaryQueryImplementation.class, position = 70)})
+public final class MavenLocalJavadocForBinaryQuery extends AbstractJavadocForBinaryQuery {
+
+    final static MavenLocalSourceForBinaryQuery SOURCE_QUERY;
+
+    static {
+        SOURCE_QUERY = new MavenLocalSourceForBinaryQuery();
+    }
+
+    public MavenLocalJavadocForBinaryQuery() {
+    }
+
+    private boolean hasSources(File binaryRootFile) {
+        SourceForBinaryQueryImplementation2.Result result = SOURCE_QUERY.tryFindSourceRoot(binaryRootFile);
+        if (result == null) {
+            return false;
+        }
+        return result.getRoots().length > 0;
+    }
+
+    @Override
+    protected JavadocForBinaryQuery.Result tryFindJavadoc(File binaryRoot) {
+        if (hasSources(binaryRoot)) {
+            // TODO: Global settings should be added to allow prefer javadoc
+            //       over sources.
+            return null;
+        }
+        
+        final FileObject binaryRootObj = FileUtil.toFileObject(binaryRoot);
+        String javadocName = MavenFileUtils.binaryToJavadocName(binaryRootObj);
+        if (javadocName == null) {
+            return null;
+        }
+        
+        File binaryRootParent = binaryRoot.getParentFile();
+        File javadocFile = new File(binaryRootParent, javadocName);
+        FileObject javadocFileObj = FileUtil.toFileObject(javadocFile);
+        if (javadocFileObj == null) {
+            return null;
+        }
+        
+        FileObject asArchive = NbFileUtils.asArchiveOrDir(javadocFileObj);
+        if (asArchive == null) {
+            return null;
+        }
+
+        return new JavadocForBinaryQuery.Result() {
+            @Override
+            public URL[] getRoots() {
+                return new URL[]{asArchive.toURL()};
+            }
+
+            @Override
+            public void addChangeListener(ChangeListener l) {
+            }
+
+            @Override
+            public void removeChangeListener(ChangeListener l) {
+            }
+        };
+    }
+}

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/MavenLocalJavadocForBinaryQuery.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/MavenLocalJavadocForBinaryQuery.java
@@ -14,7 +14,7 @@ import org.openide.util.lookup.ServiceProvider;
 import org.openide.util.lookup.ServiceProviders;
 
 @ServiceProviders({
-    @ServiceProvider(service = JavadocForBinaryQueryImplementation.class, position = 70)})
+    @ServiceProvider(service = JavadocForBinaryQueryImplementation.class)})
 public final class MavenLocalJavadocForBinaryQuery extends AbstractJavadocForBinaryQuery {
 
     final static MavenLocalSourceForBinaryQuery SOURCE_QUERY;

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/MavenLocalJavadocForBinaryQuery.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/MavenLocalJavadocForBinaryQuery.java
@@ -41,20 +41,24 @@ public final class MavenLocalJavadocForBinaryQuery extends AbstractJavadocForBin
             //       over sources.
             return null;
         }
-        
+
         final FileObject binaryRootObj = FileUtil.toFileObject(binaryRoot);
+        if (binaryRootObj == null) {
+            return null;
+        }
+
         String javadocName = MavenFileUtils.binaryToJavadocName(binaryRootObj);
         if (javadocName == null) {
             return null;
         }
-        
+
         File binaryRootParent = binaryRoot.getParentFile();
         File javadocFile = new File(binaryRootParent, javadocName);
         FileObject javadocFileObj = FileUtil.toFileObject(javadocFile);
         if (javadocFileObj == null) {
             return null;
         }
-        
+
         FileObject asArchive = NbFileUtils.asArchiveOrDir(javadocFileObj);
         if (asArchive == null) {
             return null;

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/MavenLocalSourceForBinaryQuery.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/MavenLocalSourceForBinaryQuery.java
@@ -1,0 +1,62 @@
+package org.netbeans.gradle.project.query;
+
+import java.io.File;
+import javax.swing.event.ChangeListener;
+import org.netbeans.gradle.project.util.MavenFileUtils;
+import org.netbeans.gradle.project.util.NbFileUtils;
+import org.netbeans.spi.java.queries.SourceForBinaryQueryImplementation;
+import org.netbeans.spi.java.queries.SourceForBinaryQueryImplementation2;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.util.lookup.ServiceProvider;
+import org.openide.util.lookup.ServiceProviders;
+
+@ServiceProviders({
+    @ServiceProvider(service = SourceForBinaryQueryImplementation2.class, position = 70),
+    @ServiceProvider(service = SourceForBinaryQueryImplementation.class, position = 70)})
+public final class MavenLocalSourceForBinaryQuery extends AbstractSourceForBinaryQuery {
+
+    public MavenLocalSourceForBinaryQuery() {
+    }
+
+    @Override
+    protected Result tryFindSourceRoot(File binaryRoot) {
+        final FileObject binaryRootObj = FileUtil.toFileObject(binaryRoot);
+        String sourceName = MavenFileUtils.binaryToSourceName(binaryRootObj);
+        if (sourceName == null) {
+            return null;
+        }
+        File binaryRootParent = binaryRoot.getParentFile();
+        File sourceFile = new File(binaryRootParent, sourceName);
+
+        FileObject sourceFileObj = FileUtil.toFileObject(sourceFile);
+        if (sourceFileObj == null) {
+            return null;
+        }
+        
+        FileObject asArchive = NbFileUtils.asArchiveOrDir(sourceFileObj);
+        if (asArchive == null) {
+            return null;
+        }
+
+        return new SourceForBinaryQueryImplementation2.Result() {
+            @Override
+            public boolean preferSources() {
+                return false;
+            }
+
+            @Override
+            public FileObject[] getRoots() {
+                return new FileObject[]{asArchive};
+            }
+
+            @Override
+            public void addChangeListener(ChangeListener l) {
+            }
+
+            @Override
+            public void removeChangeListener(ChangeListener l) {
+            }
+        };
+    }
+}

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/MavenLocalSourceForBinaryQuery.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/MavenLocalSourceForBinaryQuery.java
@@ -12,8 +12,8 @@ import org.openide.util.lookup.ServiceProvider;
 import org.openide.util.lookup.ServiceProviders;
 
 @ServiceProviders({
-    @ServiceProvider(service = SourceForBinaryQueryImplementation2.class, position = 70),
-    @ServiceProvider(service = SourceForBinaryQueryImplementation.class, position = 70)})
+    @ServiceProvider(service = SourceForBinaryQueryImplementation2.class),
+    @ServiceProvider(service = SourceForBinaryQueryImplementation.class)})
 public final class MavenLocalSourceForBinaryQuery extends AbstractSourceForBinaryQuery {
 
     public MavenLocalSourceForBinaryQuery() {

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/MavenLocalSourceForBinaryQuery.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/query/MavenLocalSourceForBinaryQuery.java
@@ -22,6 +22,10 @@ public final class MavenLocalSourceForBinaryQuery extends AbstractSourceForBinar
     @Override
     protected Result tryFindSourceRoot(File binaryRoot) {
         final FileObject binaryRootObj = FileUtil.toFileObject(binaryRoot);
+        if (binaryRootObj == null) {
+            return null;
+        }
+        
         String sourceName = MavenFileUtils.binaryToSourceName(binaryRootObj);
         if (sourceName == null) {
             return null;

--- a/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/util/MavenFileUtils.java
+++ b/netbeans-gradle-plugin/src/main/java/org/netbeans/gradle/project/util/MavenFileUtils.java
@@ -1,0 +1,118 @@
+package org.netbeans.gradle.project.util;
+
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+
+public final class MavenFileUtils {
+
+    public static final String POM_DIR_NAME = "pom";
+    public static final String SOURCES_CLASSIFIER = "-sources";
+    public static final String JAVADOC_CLASSIFIER = "-javadoc";
+    public static final String SNAPSHOT_SUFFIX = "-SNAPSHOT";
+
+    public static final String SOURCES_SUFFIX = SOURCES_CLASSIFIER + ".jar";
+
+    public static boolean isSourceFile(FileObject sourcePath) {
+        String name = sourcePath.getNameExt();
+        return name.endsWith(SOURCES_SUFFIX);
+    }
+
+    public static String binaryToSourceName(FileObject binaryPath) {
+        String binFileExt = binaryPath.getExt();
+        return binaryToBaseName(binaryPath) + SOURCES_CLASSIFIER + "." + binFileExt;
+    }
+
+    public static String binaryToJavadocName(FileObject binaryPath) {
+        String binFileExt = binaryPath.getExt();
+        return binaryToBaseName(binaryPath) + JAVADOC_CLASSIFIER + "." + binFileExt;
+    }
+
+    /**
+     * Extracts the base name for the given binary if the binary is stored in a
+     * custom local maven repository.
+     *
+     * @param binaryPath
+     * @return The base name of the binary without the classifier if in a custom
+     * local maven repository, else the name of the binary.
+     */
+    public static String binaryToBaseName(FileObject binaryPath) {
+        // If the binary is in a local maven repo, then Gradle does not cache
+        // and the binaries, sources and javadocs are stored in a format that 
+        // looks like this:
+
+        // ...BINARY_NAME\\BINARY_VERSION\\binary-javadoc.XXX
+        // ...BINARY_NAME\\BINARY_VERSION\\binary-sources.XXX
+        // ...BINARY_NAME\\BINARY_VERSION\\binary.XXX
+        // ...BINARY_NAME\\BINARY_VERSION\\binary-win.XXX (optional)
+        //
+        // where binary is the string BINARY_NAME-BINARY_VERSION
+        // There can be multiple binaries, for example the win binary here could 
+        // be associated with the sources
+        //
+        // If the version is a snapshot (ends in -SNAPSHOT) and it's in a local 
+        // maven repository, then binary is not BINARY_NAME-BINARY_VERSION. 
+        // Instead it's:
+        //
+        // BINARY_NAME-BINARY_VERSION_WITHOUT_SNAPSHOT-DATE-SNAPSHOT_NUM
+        //
+        // for example:
+        // foo/1.2-SNAPSHOT/foo-1.2-20110506.110000-3.jar
+        // foo/1.2-SNAPSHOT/foo-1.2-20110506.110000-3-sources.jar
+        // foo/1.2-SNAPSHOT/foo-1.2-20110506.110000-3-win.jar
+        // foo/1.2-SNAPSHOT/foo-1.2-20110506.110000-3-javadoc.jar
+        //
+        // where the snapshot was the 3rd snapshot for this version, 
+        // and it was generated at 2011/05/06 at 11:00:00)
+        FileObject hashDir = binaryPath.getParent();
+        if (hashDir == null) {
+            return binaryPath.getName();
+        }
+        FileObject binDir = hashDir.getParent();
+        if (binDir == null) {
+            return binaryPath.getName();
+        }
+
+        //File stored in local maven repository, and version is snapshot
+        if (hashDir.getNameExt().endsWith(SNAPSHOT_SUFFIX)) {
+            String mavenVersion = hashDir.getNameExt().substring(0, hashDir.getNameExt().length() - SNAPSHOT_SUFFIX.length());
+            String mavenLocalName = binDir.getNameExt() + "-" + mavenVersion;
+            if (binaryPath.getNameExt().startsWith(mavenLocalName)) {
+                Pattern p = Pattern.compile(Pattern.quote(mavenLocalName) + "-(\\d{8}\\.\\d{6}-[\\d]+)");
+                Matcher m = p.matcher(binaryPath.getName());
+                if (m.find()) {
+                    String dateTimeSnapshot = m.group(1);
+                    return mavenLocalName + "-" + dateTimeSnapshot;
+                }
+            }
+        }
+
+        //File stored in local maven repository
+        String mavenLocalName = binDir.getNameExt() + "-" + hashDir.getNameExt();
+        if (binaryPath.getNameExt().startsWith(mavenLocalName)) {
+            return mavenLocalName;
+        }
+        return binaryPath.getName(); //not in a custom local maven repository
+    }
+
+    public static String sourceToBinaryName(FileObject sourcePath) {
+        String srcFileName = sourcePath.getName();
+        if (!srcFileName.endsWith(SOURCES_CLASSIFIER)) {
+            return null;
+        }
+        String srcFileExt = sourcePath.getExt();
+
+        return srcFileName.substring(0, srcFileName.length() - SOURCES_CLASSIFIER.length())
+                + "." + srcFileExt;
+    }
+
+    public static Path toPath(FileObject fileObj) {
+        return NbFileUtils.asPath(FileUtil.toFile(fileObj));
+    }
+
+    private MavenFileUtils() {
+        throw new AssertionError();
+    }
+}

--- a/netbeans-gradle-plugin/src/test/java/org/netbeans/gradle/project/query/MavenLocalBinaryForSourceQueryTest.java
+++ b/netbeans-gradle-plugin/src/test/java/org/netbeans/gradle/project/query/MavenLocalBinaryForSourceQueryTest.java
@@ -1,0 +1,138 @@
+package org.netbeans.gradle.project.query;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.netbeans.gradle.model.util.BasicFileUtils;
+import org.netbeans.gradle.project.util.SafeTmpFolder;
+import org.netbeans.gradle.project.util.TestBinaryUtils;
+import org.openide.util.Utilities;
+
+import static org.junit.Assert.*;
+import org.netbeans.api.java.queries.BinaryForSourceQuery;
+import static org.netbeans.gradle.project.query.TestSourceQueryUtils.*;
+import org.netbeans.spi.java.queries.BinaryForSourceQueryImplementation;
+
+public class MavenLocalBinaryForSourceQueryTest {
+
+    @ClassRule
+    public static final SafeTmpFolder TMP_DIR_ROOT = new SafeTmpFolder();
+
+    private static BinaryForSourceQueryImplementation createBinaryQuery() {
+        return new MavenLocalBinaryForSourceQuery();
+    }
+
+    private void verifyBinary(URL sourceUrl, File binaryFile) {
+        BinaryForSourceQueryImplementation query = createBinaryQuery();
+
+        BinaryForSourceQuery.Result result1 = query.findBinaryRoots(sourceUrl);
+        assertNotNull("result1", result1);
+        expectSameArchive("binaryPath", binaryFile, expectedSingleFile(result1));
+    }
+
+    private void verifyNotMavenLocal(URL sourceUrl) {
+        BinaryForSourceQueryImplementation query = createBinaryQuery();
+
+        BinaryForSourceQuery.Result result1 = query.findBinaryRoots(sourceUrl);
+        assertNull("result1", result1);
+    }
+
+ @Test
+    public void testNewCacheFormatMavenLocal() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2");
+        File jar = BasicFileUtils.getSubPath(versionDir, "myproj-11.2.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File srcFile = BasicFileUtils.getSubPath(versionDir, "myproj-11.2-sources.jar");
+
+        TestBinaryUtils.createTestJar(srcFile);
+
+        URL srcUrl = Utilities.toURI(srcFile).toURL();
+        verifyBinary(srcUrl, jar);
+    }
+
+    @Test
+    public void testNewCacheFormatMavenLocalSnapshot() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "foo");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2-SNAPSHOT");
+        File jar = BasicFileUtils.getSubPath(versionDir, "foo-11.2-20110506.110000-3.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File srcFile = BasicFileUtils.getSubPath(versionDir, "foo-11.2-20110506.110000-3-sources.jar");
+
+        TestBinaryUtils.createTestJar(srcFile);
+
+        URL srcUrl = Utilities.toURI(srcFile).toURL();
+        verifyBinary(srcUrl, jar);
+    }
+
+    @Test
+    public void testNewCacheFormatRemoteSnapshot() throws IOException {
+        //this should be dealt with by the gradle cache
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "foo");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2-SNAPSHOT");
+        File jarDir = BasicFileUtils.getSubPath(versionDir, "57436");
+        File jar = BasicFileUtils.getSubPath(jarDir, "foo-11.2-SNAPSHOT.jar");
+
+        jarDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File srcDir = BasicFileUtils.getSubPath(versionDir, "25754");
+        File srcFile = BasicFileUtils.getSubPath(srcDir, "foo-11.2-SNAPSHOT-sources.jar");
+
+        srcDir.mkdirs();
+        TestBinaryUtils.createTestJar(srcFile);
+
+        URL srcUrl = Utilities.toURI(srcFile).toURL();
+        verifyNotMavenLocal(srcUrl);
+    }
+
+    @Test
+    public void testNewCacheFormatMissingSourceInMavenLocal() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2");
+        File jar = BasicFileUtils.getSubPath(versionDir, "myproj-11.2.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+        
+        File srcFile = BasicFileUtils.getSubPath(versionDir, "myproj-11.2-sources.jar");
+        //not created
+
+        URL srcUrl = Utilities.toURI(srcFile).toURL();
+        verifyNotMavenLocal(srcUrl);
+    }
+
+    @Test
+    public void testNewCacheFormatMissingSourceInMavenLocalSnapshot() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2-SNAPSHOT");
+        File jar = BasicFileUtils.getSubPath(versionDir, "myproj-11.2-20110506.110000-7.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+        
+        File srcDir = BasicFileUtils.getSubPath(versionDir, "25754");
+        File srcFile = BasicFileUtils.getSubPath(srcDir, "foo-11.2-SNAPSHOT-sources.jar");
+
+        URL srcUrl = Utilities.toURI(srcFile).toURL();
+        verifyNotMavenLocal(srcUrl);
+    }
+}

--- a/netbeans-gradle-plugin/src/test/java/org/netbeans/gradle/project/query/MavenLocalJavadocForBinaryQueryTest.java
+++ b/netbeans-gradle-plugin/src/test/java/org/netbeans/gradle/project/query/MavenLocalJavadocForBinaryQueryTest.java
@@ -1,0 +1,174 @@
+package org.netbeans.gradle.project.query;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.netbeans.api.java.queries.JavadocForBinaryQuery;
+import org.netbeans.gradle.model.util.BasicFileUtils;
+import org.netbeans.gradle.project.util.SafeTmpFolder;
+import org.netbeans.gradle.project.util.TestBinaryUtils;
+import org.netbeans.spi.java.queries.JavadocForBinaryQueryImplementation;
+import org.openide.util.Utilities;
+
+import static org.junit.Assert.*;
+import static org.netbeans.gradle.project.query.TestSourceQueryUtils.*;
+
+public class MavenLocalJavadocForBinaryQueryTest {
+
+    @ClassRule
+    public static final SafeTmpFolder TMP_DIR_ROOT = new SafeTmpFolder();
+
+    private static JavadocForBinaryQueryImplementation createJavadocQuery() {
+        return new MavenLocalJavadocForBinaryQuery();
+    }
+
+    private void verifyJavadoc(URL binaryUrl, File javadocFile, boolean hasSources) {
+        JavadocForBinaryQueryImplementation query = createJavadocQuery();
+
+        JavadocForBinaryQuery.Result result = query.findJavadoc(binaryUrl);
+        if (hasSources) {
+            //if it has sources, the javadoc shouldn't be used
+            assertNull("result", result);
+        } else {
+            assertNotNull("result", result);
+            expectSameArchive("javadocPath", javadocFile, expectedSingleFile(result));
+        }
+    }
+
+    private void verifyNotDownloadedJavadoc(URL binaryUrl) {
+        JavadocForBinaryQueryImplementation query = createJavadocQuery();
+        JavadocForBinaryQuery.Result result1 = query.findJavadoc(binaryUrl);
+        assertNull("result1", result1);
+    }
+
+    @Test
+    public void testNewCacheFormatMavenLocal() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2");
+        File jar = BasicFileUtils.getSubPath(versionDir, "myproj-11.2.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File javadocFile = BasicFileUtils.getSubPath(versionDir, "myproj-11.2-javadoc.jar");
+
+        TestBinaryUtils.createTestJar(javadocFile);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifyJavadoc(binaryUrl, javadocFile, false);
+    }
+
+    @Test
+    public void testNewCacheFormatMavenLocalWithSources() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2");
+        File jar = BasicFileUtils.getSubPath(versionDir, "myproj-11.2.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File javadocFile = BasicFileUtils.getSubPath(versionDir, "myproj-11.2-javadoc.jar");
+
+        TestBinaryUtils.createTestJar(javadocFile);
+
+        File srcFile = BasicFileUtils.getSubPath(versionDir, "myproj-11.2-sources.jar");
+
+        TestBinaryUtils.createTestJar(srcFile);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifyJavadoc(binaryUrl, javadocFile, true);
+    }
+
+    @Test
+    public void testNewCacheFormatMavenLocalMultipleBinaries() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2");
+        File jar = BasicFileUtils.getSubPath(versionDir, "myproj-11.2-win.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File javadocFile = BasicFileUtils.getSubPath(versionDir, "myproj-11.2-javadoc.jar");
+
+        TestBinaryUtils.createTestJar(javadocFile);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifyJavadoc(binaryUrl, javadocFile, false);
+    }
+
+    @Test
+    public void testNewCacheFormatMavenLocalSnapshot() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "foo");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2-SNAPSHOT");
+        File jar = BasicFileUtils.getSubPath(versionDir, "foo-11.2-20110506.110000-3.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File javadocFile = BasicFileUtils.getSubPath(versionDir, "foo-11.2-20110506.110000-3-javadoc.jar");
+
+        TestBinaryUtils.createTestJar(javadocFile);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifyJavadoc(binaryUrl, javadocFile, false);
+    }
+
+    @Test
+    public void testNewCacheFormatMavenLocalSnapshotMultipleBinaries() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "foo");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2-SNAPSHOT");
+        File jar = BasicFileUtils.getSubPath(versionDir, "foo-11.2-20110506.110000-3-win.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File javadocFile = BasicFileUtils.getSubPath(versionDir, "foo-11.2-20110506.110000-3-javadoc.jar");
+
+        TestBinaryUtils.createTestJar(javadocFile);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifyJavadoc(binaryUrl, javadocFile, false);
+    }
+
+    @Test
+    public void testNewCacheFormatMissingSourceInMavenLocal() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2");
+        File jar = BasicFileUtils.getSubPath(versionDir, "myproj-11.2.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifyNotDownloadedJavadoc(binaryUrl);
+    }
+
+    @Test
+    public void testNewCacheFormatMissingSourceInMavenLocalSnapshot() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2-SNAPSHOT");
+        File jar = BasicFileUtils.getSubPath(versionDir, "myproj-11.2-20110506.110000-7.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifyNotDownloadedJavadoc(binaryUrl);
+    }
+}

--- a/netbeans-gradle-plugin/src/test/java/org/netbeans/gradle/project/query/MavenLocalSourceForBinaryQueryTest.java
+++ b/netbeans-gradle-plugin/src/test/java/org/netbeans/gradle/project/query/MavenLocalSourceForBinaryQueryTest.java
@@ -1,0 +1,178 @@
+package org.netbeans.gradle.project.query;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.netbeans.api.java.queries.SourceForBinaryQuery;
+import org.netbeans.gradle.model.util.BasicFileUtils;
+import org.netbeans.gradle.project.util.SafeTmpFolder;
+import org.netbeans.gradle.project.util.TestBinaryUtils;
+import org.netbeans.spi.java.queries.SourceForBinaryQueryImplementation2;
+import org.openide.util.Utilities;
+
+import static org.junit.Assert.*;
+import static org.netbeans.gradle.project.query.TestSourceQueryUtils.*;
+
+public class MavenLocalSourceForBinaryQueryTest {
+
+    @ClassRule
+    public static final SafeTmpFolder TMP_DIR_ROOT = new SafeTmpFolder();
+
+    private static SourceForBinaryQueryImplementation2 createSourceQuery() {
+        return new MavenLocalSourceForBinaryQuery();
+    }
+
+    private void verifySource(URL binaryUrl, File srcFile) {
+        SourceForBinaryQueryImplementation2 query = createSourceQuery();
+
+        SourceForBinaryQuery.Result result1 = query.findSourceRoots(binaryUrl);
+        assertNotNull("result1", result1);
+        expectSameArchive("sourcesPath", srcFile, expectedSingleFile(result1));
+
+        SourceForBinaryQueryImplementation2.Result result2 = query.findSourceRoots2(binaryUrl);
+        assertNotNull("result2", result2);
+        expectSameArchive("sourcesPath", srcFile, expectedSingleFile(result2));
+        assertFalse("preferSources", result2.preferSources());
+    }
+
+    private void verifyNotDownloadedSource(URL binaryUrl) {
+        SourceForBinaryQueryImplementation2 query = createSourceQuery();
+
+        SourceForBinaryQuery.Result result1 = query.findSourceRoots(binaryUrl);
+        assertNull("result1", result1);
+
+        SourceForBinaryQueryImplementation2.Result result2 = query.findSourceRoots2(binaryUrl);
+        assertNull("result2", result2);
+    }
+
+ @Test
+    public void testNewCacheFormatMavenLocal() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2");
+        File jar = BasicFileUtils.getSubPath(versionDir, "myproj-11.2.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File srcFile = BasicFileUtils.getSubPath(versionDir, "myproj-11.2-sources.jar");
+
+        TestBinaryUtils.createTestJar(srcFile);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifySource(binaryUrl, srcFile);
+    }
+
+    @Test
+    public void testNewCacheFormatMavenLocalMultipleBinaries() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2");
+        File jar = BasicFileUtils.getSubPath(versionDir, "myproj-11.2-win.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File srcFile = BasicFileUtils.getSubPath(versionDir, "myproj-11.2-sources.jar");
+
+        TestBinaryUtils.createTestJar(srcFile);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifySource(binaryUrl, srcFile);
+    }
+
+    @Test
+    public void testNewCacheFormatMavenLocalSnapshot() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "foo");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2-SNAPSHOT");
+        File jar = BasicFileUtils.getSubPath(versionDir, "foo-11.2-20110506.110000-3.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File srcFile = BasicFileUtils.getSubPath(versionDir, "foo-11.2-20110506.110000-3-sources.jar");
+
+        TestBinaryUtils.createTestJar(srcFile);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifySource(binaryUrl, srcFile);
+    }
+
+    @Test
+    public void testNewCacheFormatMavenLocalSnapshotMultipleBinaries() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "foo");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2-SNAPSHOT");
+        File jar = BasicFileUtils.getSubPath(versionDir, "foo-11.2-20110506.110000-3-win.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File srcFile = BasicFileUtils.getSubPath(versionDir, "foo-11.2-20110506.110000-3-sources.jar");
+
+        TestBinaryUtils.createTestJar(srcFile);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifySource(binaryUrl, srcFile);
+    }
+
+    @Test
+    public void testNewCacheFormatRemoteSnapshot() throws IOException {
+        //this should be dealt with by the gradle cache
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "foo");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2-SNAPSHOT");
+        File jarDir = BasicFileUtils.getSubPath(versionDir, "57436");
+        File jar = BasicFileUtils.getSubPath(jarDir, "foo-11.2-SNAPSHOT.jar");
+
+        jarDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        File srcDir = BasicFileUtils.getSubPath(versionDir, "25754");
+        File srcFile = BasicFileUtils.getSubPath(srcDir, "foo-11.2-SNAPSHOT-sources.jar");
+
+        srcDir.mkdirs();
+        TestBinaryUtils.createTestJar(srcFile);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifyNotDownloadedSource(binaryUrl);
+    }
+
+    @Test
+    public void testNewCacheFormatMissingSourceInMavenLocal() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2");
+        File jar = BasicFileUtils.getSubPath(versionDir, "myproj-11.2.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifyNotDownloadedSource(binaryUrl);
+    }
+
+    @Test
+    public void testNewCacheFormatMissingSourceInMavenLocalSnapshot() throws IOException {
+        File gradleHome = TMP_DIR_ROOT.newFolder();
+
+        File artifactRoot = BasicFileUtils.getSubPath(gradleHome, "org", "myproj");
+        File versionDir = BasicFileUtils.getSubPath(artifactRoot, "11.2-SNAPSHOT");
+        File jar = BasicFileUtils.getSubPath(versionDir, "myproj-11.2-20110506.110000-7.jar");
+
+        versionDir.mkdirs();
+        TestBinaryUtils.createTestJar(jar);
+
+        URL binaryUrl = Utilities.toURI(jar).toURL();
+        verifyNotDownloadedSource(binaryUrl);
+    }
+}


### PR DESCRIPTION
As mentioned in https://github.com/kelemen/netbeans-gradle-project/pull/412, this adds support for  source and javadoc file resolution in a custom local maven repository. It achieves this by checking if the source/javadoc files associated with the given binary file exist in the place we expect it to be. If not, it returns a null result so that another query can handle the resolution.

I'm not sure if there is a way to access the list of loaded repositories gradle has, but if this approach proves problematic, I can look into it.

